### PR TITLE
Mark private key as sensitive

### DIFF
--- a/venafi/resource_venafi_certificate.go
+++ b/venafi/resource_venafi_certificate.go
@@ -89,9 +89,10 @@ func resourceVenafiCertificate() *schema.Resource {
 				ForceNew:    true,
 			},
 			"private_key_pem": &schema.Schema{
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
+				Type:      schema.TypeString,
+				Optional:  true,
+				Computed:  true,
+				Sensitive: true,
 			},
 			"chain": &schema.Schema{
 				Type:     schema.TypeString,


### PR DESCRIPTION
Prevent the generated private key from being leaked in logs or diffs.