### PR TITLE
Add renewal information on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,8 +128,9 @@ output "cert_private_key" {
 
 To invoke execute `terraform plan`, then `terraform apply`, and finally `terraform show` from the directory containing your Terraform configuration file (e.g. `main.tf`).
 
-## Renewing a Certificate
-The `venafi_certificate` resource handles certificate renewals as long as a terraform apply is done within the `experation_window` period. Keep in mind that this experation window in Terraform needs to match the renewal window set within your CA/TPP.
+### Renewing a Certificate
+
+The `venafi_certificate` resource handles certificate renewals as long as a terraform apply is done within the `expiration_window` period. Keep in mind that this expiration window in Terraform needs to match the renewal window set within your CA/TPP.
 
 ## Requirements for usage with Trust Protection Platform
 

--- a/README.md
+++ b/README.md
@@ -128,6 +128,8 @@ output "cert_private_key" {
 
 To invoke execute `terraform plan`, then `terraform apply`, and finally `terraform show` from the directory containing your Terraform configuration file (e.g. `main.tf`).
 
+## Renewing a Certificate
+The `venafi_certificate` resource handles certificate renewals as long as a terraform apply is done within the `experation_window` period. Keep in mind that this experation window in Terraform needs to match the renewal window set within your CA/TPP.
 
 ## Requirements for usage with Trust Protection Platform
 

--- a/website/docs/r/venafi_certificate.html.markdown
+++ b/website/docs/r/venafi_certificate.html.markdown
@@ -68,4 +68,4 @@ The following attributes are exported:
 
 ## Certificate Renewal
 
-The `venafi_certificate` resource handles certificate renewals as long as a terraform apply or plan is done within the `experation_window` period. Keep in mind that this experation window in Terraform needs to match the renewal window set within your CA/TPP.
+The `venafi_certificate` resource handles certificate renewals as long as a terraform apply is done within the `experation_window` period. Keep in mind that this experation window in Terraform needs to match the renewal window set within your CA/TPP.

--- a/website/docs/r/venafi_certificate.html.markdown
+++ b/website/docs/r/venafi_certificate.html.markdown
@@ -68,4 +68,4 @@ The following attributes are exported:
 
 ## Certificate Renewal
 
-The `venafi_certificate` resource handles certificate renewals as long as a terraform apply is done within the `experation_window` period. Keep in mind that this experation window in Terraform needs to match the renewal window set within your CA/TPP.
+The `venafi_certificate` resource handles certificate renewals as long as a terraform apply is done within the `expiration_window` period. Keep in mind that this expiration window in Terraform needs to match the renewal window set within your CA/TPP.

--- a/website/docs/r/venafi_certificate.html.markdown
+++ b/website/docs/r/venafi_certificate.html.markdown
@@ -65,3 +65,7 @@ The following attributes are exported:
   concatenated together.
 
 * `certificate` - The X509 certificate in PEM format.
+
+## Certificate Renewal
+
+The `venafi_certificate` resource handles certificate renewals as long as a terraform apply or plan is done within the `experation_window` period. Keep in mind that this experation window in Terraform needs to match the renewal window set within your CA/TPP.


### PR DESCRIPTION
Added some information about certificate renewal on the README pages. Helps with clarity around the renewal process with our plugin. 