### PR TITLE
Outage predict migration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,6 @@ CURRENT_DIR := $(patsubst %/,%,$(dir $(realpath $(MKFILE_PATH))))
 #Plugin information
 PLUGIN_NAME := terraform-provider-venafi
 PLUGIN_DIR := pkg/bin
-PLUGIN_PATH := $(PLUGIN_DIR)/$(PLUGIN_NAME)
 DIST_DIR := pkg/dist
 
 ifdef BUILD_NUMBER
@@ -27,10 +26,49 @@ ZIP_VERSION := $(shell echo ${VERSION} | cut -c 2-)
 TEST?=$$(go list ./... |grep -v 'vendor')
 GOFMT_FILES?=$$(find . -name '*.go' |grep -v vendor)
 
+# Get the OS dinamically.
+# credits to https://gist.github.com/sighingnow/deee806603ec9274fd47
+OS_STR :=
+CPU_STR :=
+ifeq ($(OS),Windows_NT)
+	OS_STR := windows
+	ifeq ($(PROCESSOR_ARCHITECTURE),AMD64)
+		CPU_STR := amd64
+	endif
+	ifeq ($(PROCESSOR_ARCHITECTURE),x86)
+		CPU_STR := 386
+	endif
+else
+	UNAME_S := $(shell uname -s)
+	ifeq ($(UNAME_S),Linux)
+		OS_STR := linux
+
+		UNAME_P := $(shell uname -p)
+		ifeq ($(UNAME_P),x86_64)
+			CPU_STR := amd64
+		endif
+		ifneq ($(filter %86,$(UNAME_P)),)
+			CPU_STR := 386
+		endif
+	endif
+	ifeq ($(UNAME_S),Darwin)
+		OS_STR := darwin
+		CPU_STR := amd64
+	endif
+endif
+
+TERRAFORM_TEST_VERSION := 99.9.9
+TERRAFORM_TEST_DIR := terraform.d/plugins/registry.terraform.io/terraform-providers/venafi/$(TERRAFORM_TEST_VERSION)/$(OS_STR)_$(CPU_STR)
+
+os:
+	@echo $(OS_STRING)
+
 all: build test testacc
 
-
 #Build
+build_dev_dynamic:
+	env CGO_ENABLED=0 GOOS=$(OS_STR)   GOARCH=$(CPU_STR) go build -ldflags '-s -w -extldflags "-static"' -a -o $(PLUGIN_DIR)/$(OS_STR)/$(PLUGIN_NAME)_$(VERSION) || exit 1
+
 build_dev:
 	env CGO_ENABLED=0 GOOS=linux   GOARCH=amd64 go build -ldflags '-s -w -extldflags "-static"' -a -o $(PLUGIN_DIR)/linux/$(PLUGIN_NAME)_$(VERSION) || exit 1
 
@@ -84,6 +122,7 @@ test_go:
 	go test -i $(TEST) || exit 1
 	echo $(TEST) | \
 		xargs -t -n4 go test $(TESTARGS) -timeout=30s -parallel=4
+
 testacc:
 	TF_ACC=1 go test $(TEST) -v $(TESTARGS) -timeout 120m
 
@@ -93,10 +132,15 @@ fmt:
 fmtcheck:
 	@sh -c "'$(CURDIR)/scripts/gofmtcheck.sh'"
 
-#Integration tests using real terrafomr binary
+# Integration tests using real terraform binary
+# Right now only works in linux platform
 test_e2e: e2e_init test_e2e_dev test_e2e_tpp test_e2e_cloud test_e2e_tpp_token
 
-e2e_init:
+# This step copies the built terraform plugin to the terraform folder structure, so  changes can be tested.
+e2e_init: build_dev_dynamic
+	mkdir -p $(TERRAFORM_TEST_DIR)
+	mv $(PLUGIN_DIR)/$(OS_STR)/$(PLUGIN_NAME)_$(VERSION) $(TERRAFORM_TEST_DIR)/$(PLUGIN_NAME)_v$(TERRAFORM_TEST_VERSION)
+	chmod 755 $(TERRAFORM_TEST_DIR)/$(PLUGIN_NAME)_v$(TERRAFORM_TEST_VERSION)
 	terraform init
 
 test_e2e_tpp:

--- a/Makefile
+++ b/Makefile
@@ -59,6 +59,7 @@ endif
 
 TERRAFORM_TEST_VERSION := 99.9.9
 TERRAFORM_TEST_DIR := terraform.d/plugins/registry.terraform.io/terraform-providers/venafi/$(TERRAFORM_TEST_VERSION)/$(OS_STR)_$(CPU_STR)
+TERRAFORM_TEST_DIR_JENKINS := terraform.d/plugins/registry.terraform.io/terraform-providers/venafi/$(TERRAFORM_TEST_VERSION)/linux_amd64
 
 os:
 	@echo $(OS_STRING)
@@ -133,15 +134,24 @@ fmtcheck:
 	@sh -c "'$(CURDIR)/scripts/gofmtcheck.sh'"
 
 # Integration tests using real terraform binary
-# Right now only works in linux platform
 test_e2e: e2e_init test_e2e_dev test_e2e_tpp test_e2e_cloud test_e2e_tpp_token
+
+# Integration tests using jenkins
+test_e2e_jenkins: e2e_init_jenkins test_e2e_dev test_e2e_tpp test_e2e_cloud test_e2e_tpp_token
 
 # This step copies the built terraform plugin to the terraform folder structure, so  changes can be tested.
 e2e_init: build_dev_dynamic
-	echo uname -s
-	echo uname -p
+	echo $(shell uname -s)
+	echo $(shell uname -p)
 	mkdir -p $(TERRAFORM_TEST_DIR)
 	mv $(PLUGIN_DIR)/$(OS_STR)/$(PLUGIN_NAME)_$(VERSION) $(TERRAFORM_TEST_DIR)/$(PLUGIN_NAME)_v$(TERRAFORM_TEST_VERSION)
+	chmod 755 $(TERRAFORM_TEST_DIR)/$(PLUGIN_NAME)_v$(TERRAFORM_TEST_VERSION)
+	terraform init
+
+# This step copies the built terraform plugin to the terraform folder structure, so  changes can be tested.
+e2e_init_jenkins: build_dev
+	mkdir -p $(TERRAFORM_TEST_DIR)
+	mv $(PLUGIN_DIR)/linux/$(PLUGIN_NAME)_$(VERSION) $(TERRAFORM_TEST_DIR)/$(PLUGIN_NAME)_v$(TERRAFORM_TEST_VERSION)
 	chmod 755 $(TERRAFORM_TEST_DIR)/$(PLUGIN_NAME)_v$(TERRAFORM_TEST_VERSION)
 	terraform init
 

--- a/Makefile
+++ b/Makefile
@@ -138,6 +138,8 @@ test_e2e: e2e_init test_e2e_dev test_e2e_tpp test_e2e_cloud test_e2e_tpp_token
 
 # This step copies the built terraform plugin to the terraform folder structure, so  changes can be tested.
 e2e_init: build_dev_dynamic
+	echo uname -s
+	echo uname -p
 	mkdir -p $(TERRAFORM_TEST_DIR)
 	mv $(PLUGIN_DIR)/$(OS_STR)/$(PLUGIN_NAME)_$(VERSION) $(TERRAFORM_TEST_DIR)/$(PLUGIN_NAME)_v$(TERRAFORM_TEST_VERSION)
 	chmod 755 $(TERRAFORM_TEST_DIR)/$(PLUGIN_NAME)_v$(TERRAFORM_TEST_VERSION)

--- a/Makefile
+++ b/Makefile
@@ -46,9 +46,12 @@ else
 		UNAME_P := $(shell uname -p)
 		ifeq ($(UNAME_P),x86_64)
 			CPU_STR := amd64
-		endif
-		ifneq ($(filter %86,$(UNAME_P)),)
-			CPU_STR := 386
+		else
+			ifneq ($(filter %86,$(UNAME_P)),)
+				CPU_STR := 386
+			else
+				CPU_STR := amd64
+			endif
 		endif
 	endif
 	ifeq ($(UNAME_S),Darwin)
@@ -141,8 +144,6 @@ test_e2e_jenkins: e2e_init_jenkins test_e2e_dev test_e2e_tpp test_e2e_cloud test
 
 # This step copies the built terraform plugin to the terraform folder structure, so  changes can be tested.
 e2e_init: build_dev_dynamic
-	echo $(shell uname -s)
-	echo $(shell uname -p)
 	mkdir -p $(TERRAFORM_TEST_DIR)
 	mv $(PLUGIN_DIR)/$(OS_STR)/$(PLUGIN_NAME)_$(VERSION) $(TERRAFORM_TEST_DIR)/$(PLUGIN_NAME)_v$(TERRAFORM_TEST_VERSION)
 	chmod 755 $(TERRAFORM_TEST_DIR)/$(PLUGIN_NAME)_v$(TERRAFORM_TEST_VERSION)

--- a/Makefile
+++ b/Makefile
@@ -139,20 +139,10 @@ fmtcheck:
 # Integration tests using real terraform binary
 test_e2e: e2e_init test_e2e_dev test_e2e_tpp test_e2e_cloud test_e2e_tpp_token
 
-# Integration tests using jenkins
-test_e2e_jenkins: e2e_init_jenkins test_e2e_dev test_e2e_tpp test_e2e_cloud test_e2e_tpp_token
-
 # This step copies the built terraform plugin to the terraform folder structure, so  changes can be tested.
 e2e_init: build_dev_dynamic
 	mkdir -p $(TERRAFORM_TEST_DIR)
 	mv $(PLUGIN_DIR)/$(OS_STR)/$(PLUGIN_NAME)_$(VERSION) $(TERRAFORM_TEST_DIR)/$(PLUGIN_NAME)_v$(TERRAFORM_TEST_VERSION)
-	chmod 755 $(TERRAFORM_TEST_DIR)/$(PLUGIN_NAME)_v$(TERRAFORM_TEST_VERSION)
-	terraform init
-
-# This step copies the built terraform plugin to the terraform folder structure, so  changes can be tested.
-e2e_init_jenkins: build_dev
-	mkdir -p $(TERRAFORM_TEST_DIR)
-	mv $(PLUGIN_DIR)/linux/$(PLUGIN_NAME)_$(VERSION) $(TERRAFORM_TEST_DIR)/$(PLUGIN_NAME)_v$(TERRAFORM_TEST_VERSION)
 	chmod 755 $(TERRAFORM_TEST_DIR)/$(PLUGIN_NAME)_v$(TERRAFORM_TEST_VERSION)
 	terraform init
 

--- a/go.mod
+++ b/go.mod
@@ -3,8 +3,7 @@ module github.com/terraform-providers/terraform-provider-venafi
 go 1.12
 
 require (
-	github.com/Venafi/vcert v3.18.4+incompatible
-	github.com/Venafi/vcert/v4 v4.11.1
+	github.com/Venafi/vcert/v4 v4.13.0
 	github.com/client9/misspell v0.3.4
 	github.com/golangci/golangci-lint v1.21.0
 	github.com/hashicorp/terraform-plugin-sdk v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -27,6 +27,8 @@ github.com/Venafi/vcert v3.18.4+incompatible h1:mDXSjd+EpXa8YEkEo9Oad19E270aiPJJ
 github.com/Venafi/vcert v3.18.4+incompatible/go.mod h1:3dpfrCI+31cDZosD+1UX8GFziVFORaegByXtzT1dwNo=
 github.com/Venafi/vcert/v4 v4.11.1 h1:BmV17mEbNIxIrJZhKO47AIHQTHDIZBOntgwqkrRySPU=
 github.com/Venafi/vcert/v4 v4.11.1/go.mod h1:OE+UZ0cj8qqVUuk0u7R4GIk4ZB6JMSf/WySqnBPNwws=
+github.com/Venafi/vcert/v4 v4.13.0 h1:A6kiHCw+i1Fs6J7lWcTw5mBFUk/Nh8xTIwgCfdDbNH0=
+github.com/Venafi/vcert/v4 v4.13.0/go.mod h1:Z3sJFoAurFNXPpoSUSHq46aIeHLiGQEMDhprfxlpofQ=
 github.com/agext/levenshtein v1.2.1 h1:QmvMAjj2aEICytGiWzmxoE0x2KZvE0fvmqMOfy2tjT8=
 github.com/agext/levenshtein v1.2.1/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
 github.com/agext/levenshtein v1.2.2 h1:0S/Yg6LYmFJ5stwQeRp6EeOcCbj7xiqQSdNelsXvaqE=
@@ -347,6 +349,7 @@ github.com/onsi/ginkgo v1.10.1/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+
 github.com/onsi/gomega v1.4.3/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
 github.com/onsi/gomega v1.7.0/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
+github.com/pavel-v-chernykh/keystore-go/v4 v4.1.0/go.mod h1:2ejgys4qY+iNVW1IittZhyRYA6MNv8TgM6VHqojbB9g=
 github.com/pelletier/go-toml v1.2.0 h1:T5zMGML61Wp+FlcbWjRDT7yAxhJNAiPPLOFECq181zc=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/pierrec/lz4 v2.0.5+incompatible/go.mod h1:pdkljMzZIN41W+lC3N2tnIh5sFi+IEE17M5jbnwPHcY=

--- a/venafi/provider.go
+++ b/venafi/provider.go
@@ -185,7 +185,14 @@ func normalizeZone(zone string) string {
 		return zone
 	}
 
-	newZone := strings.Replace(zone, "\\", "", 1)
-	log.Printf("Normalized zone : %s", newZone)
-	return newZone
+	values := strings.Split(zone, "\\")
+	// string is already normalized, nothing to do here
+	if len(values) <= 2 {
+		log.Printf("Normalized zone : %s", zone)
+		return zone
+	} else {
+		newZone := strings.Replace(zone, "\\", "", 1)
+		log.Printf("Normalized zone : %s", newZone)
+		return newZone
+	}
 }

--- a/venafi/provider.go
+++ b/venafi/provider.go
@@ -98,6 +98,7 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 	tppPassword := d.Get("tpp_password").(string)
 	accessToken := d.Get("access_token").(string)
 	zone := d.Get("zone").(string)
+	log.Printf("===ZONE==== : %s", zone)
 	devMode := d.Get("dev_mode").(bool)
 	trustBundle := d.Get("trust_bundle").(string)
 

--- a/venafi/provider.go
+++ b/venafi/provider.go
@@ -7,6 +7,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 	"log"
+	"strings"
 )
 
 const (
@@ -104,6 +105,8 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 
 	var cfg vcert.Config
 
+	zone = normalizeZone(zone)
+
 	if devMode {
 		log.Print(messageUseDevMode)
 		cfg = vcert.Config{
@@ -175,4 +178,14 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 		return nil, err
 	}
 	return &cfg, nil
+}
+
+func normalizeZone(zone string) string {
+	if zone == "" {
+		return zone
+	}
+
+	newZone := strings.Replace(zone, "\\", "", 1)
+	log.Printf("Normalized zone : %s", newZone)
+	return newZone
 }

--- a/versions.tf
+++ b/versions.tf
@@ -1,0 +1,11 @@
+terraform {
+  required_providers {
+    random = {
+      source = "hashicorp/random"
+    }
+    venafi = {
+      source = "terraform-providers/venafi"
+    }
+  }
+  required_version = ">= 0.13"
+}


### PR DESCRIPTION
Updated vcert dependency to use the new version with support for the new OutagePredict API.
Updated Makefile to create a local structure from which Terraform will pickup the plugin when built.
Added versions.tf file to comply with the new structure of Terraform 0.13.0
Updated code to normalize the zone value (removes unnecessary) before passing it to vcert sdk.