### PR TITLE
Updated versions.tf to reflect changes in Venafi provider.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,8 +61,7 @@ else
 endif
 
 TERRAFORM_TEST_VERSION := 99.9.9
-TERRAFORM_TEST_DIR := terraform.d/plugins/registry.terraform.io/terraform-providers/venafi/$(TERRAFORM_TEST_VERSION)/$(OS_STR)_$(CPU_STR)
-TERRAFORM_TEST_DIR_JENKINS := terraform.d/plugins/registry.terraform.io/terraform-providers/venafi/$(TERRAFORM_TEST_VERSION)/linux_amd64
+TERRAFORM_TEST_DIR := terraform.d/plugins/registry.terraform.io/venafi/venafi/$(TERRAFORM_TEST_VERSION)/$(OS_STR)_$(CPU_STR)
 
 os:
 	@echo $(OS_STRING)

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
       source = "hashicorp/random"
     }
     venafi = {
-      source = "terraform-providers/venafi"
+      source = "Venafi/venafi"
     }
   }
   required_version = ">= 0.13"


### PR DESCRIPTION
The new home for terraform venafi plugin is /venafi/venafi.

Before it was /terraform-providers/venafi