### PR TITLE
Zone normalization fix

### DIFF
--- a/venafi/provider.go
+++ b/venafi/provider.go
@@ -99,7 +99,7 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 	tppPassword := d.Get("tpp_password").(string)
 	accessToken := d.Get("access_token").(string)
 	zone := d.Get("zone").(string)
-	log.Printf("===ZONE==== : %s", zone)
+	log.Printf("====ZONE==== : %s", zone)
 	devMode := d.Get("dev_mode").(bool)
 	trustBundle := d.Get("trust_bundle").(string)
 
@@ -186,13 +186,16 @@ func normalizeZone(zone string) string {
 	}
 
 	values := strings.Split(zone, "\\")
-	// string is already normalized, nothing to do here
-	if len(values) <= 2 {
-		log.Printf("Normalized zone : %s", zone)
-		return zone
-	} else {
-		newZone := strings.Replace(zone, "\\", "", 1)
-		log.Printf("Normalized zone : %s", newZone)
-		return newZone
+	newZone := ""
+	for i, z := range values {
+		if len(z) > 0 {
+			newZone += z
+
+			if i < len(values)-1 {
+				newZone += "\\"
+			}
+		}
 	}
+	log.Printf("Normalized zone : %s", newZone)
+	return newZone
 }

--- a/venafi/provider_test.go
+++ b/venafi/provider_test.go
@@ -1,6 +1,8 @@
 package venafi
 
 import (
+	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
@@ -29,6 +31,24 @@ func TestProvider_impl(t *testing.T) {
 	var _ terraform.ResourceProvider = Provider()
 }
 
+func TestNormalizedZones(t *testing.T) {
+	zones := []string{
+		"Open Source\\vcert",
+		"Open Source Integrations\\\\Unrestricted",
+		"Open Source Integrations\\Unrestricted",
+		"Certificates\\Automation\\Terraform",
+		"Certificates\\\\Automation\\\\Terraform",
+	}
+	var re, _ = regexp.Compile("^[\\w\\-]+(\\s?[\\w\\-]+)*(\\\\[\\w\\-]+(\\s?[\\w\\-]+)*)*$")
+
+	for _, zone := range zones {
+		newZone := normalizeZone(zone)
+
+		if !re.MatchString(newZone) {
+			t.Fatal(fmt.Printf("Zone %s is not normalized", newZone))
+		}
+	}
+}
 func testAccPreCheck(t *testing.T) {
 	// We will use this function later on to make sure our test environment is valid.
 	// For example, you can make sure here that some environment variables are set.


### PR DESCRIPTION
Updated logic to normalize the zone string. Now it should consistently remove the double forward slash "\\" regardless of the number of sections in the zone path.

E.g."Foo\\Bar\\Venafi\\asd" is now normalized correctly into "Foo\Bar\Venafi\asd"

Added test to check for issues in zone paths 