### PR TITLE
Fix for zones with complete path

### DIFF
--- a/venafi/provider.go
+++ b/venafi/provider.go
@@ -196,6 +196,11 @@ func normalizeZone(zone string) string {
 			}
 		}
 	}
+	//Add leading forward slash when the zone includes the VED\Policy prefix
+	if strings.HasPrefix(newZone, "VED") {
+		newZone = "\\" + newZone
+	}
+
 	log.Printf("Normalized zone : %s", newZone)
 	return newZone
 }

--- a/venafi/provider.go
+++ b/venafi/provider.go
@@ -196,7 +196,7 @@ func normalizeZone(zone string) string {
 			}
 		}
 	}
-	//Add leading forward slash when the zone includes the VED\Policy prefix
+	//Add leading forward slash when the zone includes the "VED" prefix
 	if strings.HasPrefix(newZone, "VED") {
 		newZone = "\\" + newZone
 	}

--- a/venafi/provider_test.go
+++ b/venafi/provider_test.go
@@ -38,8 +38,10 @@ func TestNormalizedZones(t *testing.T) {
 		"Open Source Integrations\\Unrestricted",
 		"Certificates\\Automation\\Terraform",
 		"Certificates\\\\Automation\\\\Terraform",
+		"\\VED\\Policy\\One\\Two\\Three",
+		"\\\\VED\\\\Policy\\\\One\\\\Two\\\\Three",
 	}
-	var re, _ = regexp.Compile("^[\\w\\-]+(\\s?[\\w\\-]+)*(\\\\[\\w\\-]+(\\s?[\\w\\-]+)*)*$")
+	var re, _ = regexp.Compile("^(\\\\VED | [\\w\\-]+) (\\s?[\\w\\-]+)* (\\\\[\\w\\-]+(\\s?[\\w\\-]+)*)*$")
 
 	for _, zone := range zones {
 		newZone := normalizeZone(zone)


### PR DESCRIPTION
Updated code that strips double forward slashes from zone string to include the leading forward slash when the zone starts with the name of the TPP root folder (VED). E.g.

\\VED\\Policy\\zone\\one\\two now is correctly transformed to:
\VED\Policy\zone\one\two