### PR TITLE
Removed extra white spaces from regex string

### DIFF
--- a/venafi/provider_test.go
+++ b/venafi/provider_test.go
@@ -41,7 +41,7 @@ func TestNormalizedZones(t *testing.T) {
 		"\\VED\\Policy\\One\\Two\\Three",
 		"\\\\VED\\\\Policy\\\\One\\\\Two\\\\Three",
 	}
-	var re, _ = regexp.Compile("^(\\\\VED | [\\w\\-]+) (\\s?[\\w\\-]+)* (\\\\[\\w\\-]+(\\s?[\\w\\-]+)*)*$")
+	var re, _ = regexp.Compile("^(\\\\VED|[\\w\\-]+)(\\s?[\\w\\-]+)*(\\\\[\\w\\-]+(\\s?[\\w\\-]+)*)*$")
 
 	for _, zone := range zones {
 		newZone := normalizeZone(zone)


### PR DESCRIPTION
Removed wrong-placed white spaces in regex string that causes the test to fail.