### PR TITLE
Fixes link redirection

### DIFF
--- a/examples/citrix_adc/README.md
+++ b/examples/citrix_adc/README.md
@@ -107,7 +107,7 @@ citrix_service_group_members = [ "192.168.6.201:8001", "192.168.6.201:8002", "19
 
 ### Step 2: Set up your main Terraform config file
 
-> **IMPORTANT!** If not already done, make sure your local provider is [installed properly](./base/README.md).
+> **IMPORTANT!** If not already done, make sure your local provider is [installed properly](./../base/README.md).
 
 1. Declare that the Venafi and Citrix ADC providers are required:
     ```


### PR DESCRIPTION
Fixes wrong link redirect from citrix example to the base documentation to create a local provider