### PR TITLE
fixing typo

### DIFF
--- a/venafi/resource_venafi_ssh_certificate.go
+++ b/venafi/resource_venafi_ssh_certificate.go
@@ -86,7 +86,7 @@ func resourceVenafiSshCertificate() *schema.Resource {
 			},
 			"public_key_method": &schema.Schema{
 				Type:        schema.TypeString,
-				Description: "If the plubic key will be: local, service, generated",
+				Description: "If the public key will be: file provided or local, service generated",
 				Optional:    true,
 				Default:     "local",
 				ForceNew:    true,

--- a/website/docs/r/venafi_ssh_certificate.html.markdown
+++ b/website/docs/r/venafi_ssh_certificate.html.markdown
@@ -48,7 +48,7 @@ The following arguments are supported:
 
 * `public_key` - (Optional, string) The OpenSSH formatted public key that will be used to generate the SSH certificate.
 
-* `public_key_method` - (Optional, string) Specifies whether the public key will be "local" (default) or "service" generated.
+* `public_key_method` - (Optional, string) Specifies whether the public key will be "local" (default), "file" or "service" generated.
 
 * `principal` - (Optional, set of strings) A list of user names for whom the requested certificate will be valid.
 


### PR DESCRIPTION
fixing typo and add file provided on public_key_method for venafi ssh resource