### PR TITLE
Backward compatibility pkcs1 fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.15.5 (April 14, 2022)
+
+Fixed a bug in backward compatibility with PKCS#1 Keys
+
 ## 0.15.4 (April 8, 2022)
 
 Added support for SANs attributes

--- a/README.md
+++ b/README.md
@@ -128,10 +128,11 @@ specify any desired version constraints for the provider in the `provider` block
 using the
 [older way to manage provider versions](https://www.terraform.io/docs/configuration/providers.html#version-an-older-way-to-manage-provider-versions).
 
-> :warning: **We dropped support for RSA PKCS#1 formatted keys in version 15.0 and
-also for EC Keys in version 0.15.4 (you can find out more about this transition 
-in [here](https://github.com/Venafi/vcert/releases/tag/v4.17.0))**. For backward 
-compatibility during Terraform state refresh please update to version 0.15.5 or above
+> :warning: **We dropped support for RSA PKCS#1 formatted keys for TLS certificates
+in version 15.0 and also for EC Keys in version 0.15.4 (you can find out more about
+this transition in [here](https://github.com/Venafi/vcert/releases/tag/v4.17.0))**.
+For backward compatibility during Terraform state refresh please update to version
+0.15.5 or above.
 
 1. Declare that the Venafi Provider is required:
 

--- a/README.md
+++ b/README.md
@@ -128,6 +128,11 @@ specify any desired version constraints for the provider in the `provider` block
 using the
 [older way to manage provider versions](https://www.terraform.io/docs/configuration/providers.html#version-an-older-way-to-manage-provider-versions).
 
+> :warning: **We dropped support for RSA PKCS#1 formatted keys in version 15.0 and
+also for EC Keys in version 0.15.4 (you can find out more about this transition 
+in [here](https://github.com/Venafi/vcert/releases/tag/v4.17.0))**. For backward 
+compatibility during Terraform state refresh please update to version 0.15.5 or above
+
 1. Declare that the Venafi Provider is required:
 
    ```text
@@ -135,7 +140,7 @@ using the
      required_providers {
        venafi = {
          source = "venafi/venafi"
-         version = "~> 0.13.0"
+         version = "~> 0.15.5"
        }
      }
      required_version = ">= 0.13"

--- a/venafi/resource_venafi_certificate_test.go
+++ b/venafi/resource_venafi_certificate_test.go
@@ -348,10 +348,8 @@ output "private_key" {
 type KeyFormat int
 
 const (
-	issuer_hint                    = "MICROSOFT"
-	valid_days                     = 30
-	expectedPrivKeyPKCS1 KeyFormat = iota
-	expectedPrivKeyPKCS8
+	issuer_hint = "MICROSOFT"
+	valid_days  = 30
 )
 
 func TestDevSignedCert(t *testing.T) {
@@ -368,7 +366,7 @@ func TestDevSignedCert(t *testing.T) {
 			r.TestStep{
 				Config: config,
 				Check: func(s *terraform.State) error {
-					err := checkStandardCertPKCS8(t, &data, s)
+					err := checkStandardCert(t, &data, s)
 					if err != nil {
 						return err
 					}
@@ -393,7 +391,7 @@ func TestDevSignedCertECDSA(t *testing.T) {
 			r.TestStep{
 				Config: config,
 				Check: func(s *terraform.State) error {
-					err := checkStandardCertPKCS8(t, &data, s)
+					err := checkStandardCert(t, &data, s)
 					if err != nil {
 						return err
 					}
@@ -420,7 +418,7 @@ func TestVaasSignedCert(t *testing.T) {
 			r.TestStep{
 				Config: config,
 				Check: func(s *terraform.State) error {
-					err := checkStandardCertPKCS8(t, &data, s)
+					err := checkStandardCert(t, &data, s)
 					if err != nil {
 						return err
 					}
@@ -433,7 +431,7 @@ func TestVaasSignedCert(t *testing.T) {
 				Check: func(s *terraform.State) error {
 					t.Log("Testing VaaS certificate second run")
 					gotSerial := data.serial
-					err := checkStandardCertPKCS8(t, &data, s)
+					err := checkStandardCert(t, &data, s)
 					if err != nil {
 						return err
 					} else {
@@ -479,7 +477,7 @@ func TestVaasSignedCertUpdateRenew(t *testing.T) {
 			r.TestStep{
 				Config: config,
 				Check: func(s *terraform.State) error {
-					err := checkStandardCertPKCS8(t, &data, s)
+					err := checkStandardCert(t, &data, s)
 					if err != nil {
 						return err
 					}
@@ -494,7 +492,7 @@ func TestVaasSignedCertUpdateRenew(t *testing.T) {
 				Check: func(s *terraform.State) error {
 					t.Log("Testing TPP certificate update")
 					gotSerial := data.serial
-					err := checkStandardCertPKCS8(t, &data, s)
+					err := checkStandardCert(t, &data, s)
 					if err != nil {
 						return err
 					} else {
@@ -536,7 +534,7 @@ func TestVaasSignedCertUpdateWithCertDurationFromZoneWithGreaterExpWindow(t *tes
 				Config: config,
 				Check: func(s *terraform.State) error {
 
-					err := checkStandardCertPKCS8(t, &data, s)
+					err := checkStandardCert(t, &data, s)
 					if err != nil {
 						return err
 					}
@@ -558,7 +556,7 @@ func TestVaasSignedCertUpdateWithCertDurationFromZoneWithGreaterExpWindow(t *tes
 				Check: func(s *terraform.State) error {
 					t.Log("Testing TPP certificate update")
 					gotSerial := data.serial
-					err := checkStandardCertPKCS8(t, &data, s)
+					err := checkStandardCert(t, &data, s)
 					if err != nil {
 						return err
 					} else {
@@ -601,7 +599,7 @@ func TestVaasSignedCertUpdateSetGreaterExpWindow(t *testing.T) {
 			r.TestStep{
 				Config: config,
 				Check: func(s *terraform.State) error {
-					err := checkStandardCertPKCS8(t, &data, s)
+					err := checkStandardCert(t, &data, s)
 					if err != nil {
 						return err
 					}
@@ -614,7 +612,7 @@ func TestVaasSignedCertUpdateSetGreaterExpWindow(t *testing.T) {
 				Check: func(s *terraform.State) error {
 					t.Log("Testing TPP certificate update")
 					gotSerial := data.serial
-					err := checkStandardCertPKCS8(t, &data, s)
+					err := checkStandardCert(t, &data, s)
 					if err != nil {
 						return err
 					}
@@ -660,7 +658,7 @@ func TestTPPSignedCertUpdate(t *testing.T) {
 				Config: config,
 				Check: func(s *terraform.State) error {
 					t.Log("Issuing TPP certificate with CN", data.cn)
-					return checkStandardCertPKCS8(t, &data, s)
+					return checkStandardCert(t, &data, s)
 				},
 				ExpectNonEmptyPlan: true,
 			},
@@ -669,7 +667,7 @@ func TestTPPSignedCertUpdate(t *testing.T) {
 				Check: func(s *terraform.State) error {
 					t.Log("Testing TPP certificate update")
 					gotSerial := data.serial
-					err := checkStandardCertPKCS8(t, &data, s)
+					err := checkStandardCert(t, &data, s)
 					if err != nil {
 						return err
 					} else {
@@ -708,7 +706,7 @@ func TestTPPSignedCert(t *testing.T) {
 				Config: config,
 				Check: func(s *terraform.State) error {
 					t.Log("Issuing TPP certificate with CN", data.cn)
-					return checkStandardCertPKCS8(t, &data, s)
+					return checkStandardCert(t, &data, s)
 				},
 			},
 			r.TestStep{
@@ -716,7 +714,7 @@ func TestTPPSignedCert(t *testing.T) {
 				Check: func(s *terraform.State) error {
 					t.Log("Testing TPP certificate second run")
 					gotSerial := data.serial
-					err := checkStandardCertPKCS8(t, &data, s)
+					err := checkStandardCert(t, &data, s)
 					if err != nil {
 						return err
 					} else {
@@ -754,7 +752,7 @@ func TestTPPECDSASignedCert(t *testing.T) {
 				Config: config,
 				Check: func(s *terraform.State) error {
 					t.Log("Issuing TPP certificate with CN", data.cn)
-					return checkStandardCertPKCS8(t, &data, s)
+					return checkStandardCert(t, &data, s)
 				},
 			},
 			r.TestStep{
@@ -762,7 +760,7 @@ func TestTPPECDSASignedCert(t *testing.T) {
 				Check: func(s *terraform.State) error {
 					t.Log("Testing TPP certificate second run")
 					gotSerial := data.serial
-					err := checkStandardCertPKCS8(t, &data, s)
+					err := checkStandardCert(t, &data, s)
 					if err != nil {
 						return err
 					} else {
@@ -811,7 +809,7 @@ func TestTokenSignedCertUpdateRenew(t *testing.T) {
 				Config: config,
 				Check: func(s *terraform.State) error {
 					t.Log("Issuing TPP certificate with CN", data.cn)
-					return checkStandardCertPKCS8(t, &data, s)
+					return checkStandardCert(t, &data, s)
 				},
 				ExpectNonEmptyPlan: true,
 			},
@@ -820,7 +818,7 @@ func TestTokenSignedCertUpdateRenew(t *testing.T) {
 				Check: func(s *terraform.State) error {
 					t.Log("Testing TPP Token certificate update")
 					gotSerial := data.serial
-					err := checkStandardCertPKCS8(t, &data, s)
+					err := checkStandardCert(t, &data, s)
 					if err != nil {
 						return err
 					} else {
@@ -859,7 +857,7 @@ func TestTokenSignedCert(t *testing.T) {
 				Config: config,
 				Check: func(s *terraform.State) error {
 					t.Log("Issuing TPP certificate with CN", data.cn)
-					return checkStandardCertPKCS8(t, &data, s)
+					return checkStandardCert(t, &data, s)
 				},
 			},
 			r.TestStep{
@@ -867,7 +865,7 @@ func TestTokenSignedCert(t *testing.T) {
 				Check: func(s *terraform.State) error {
 					t.Log("Testing TPP certificate second run")
 					gotSerial := data.serial
-					err := checkStandardCertPKCS8(t, &data, s)
+					err := checkStandardCert(t, &data, s)
 					if err != nil {
 						return err
 					} else {
@@ -905,7 +903,7 @@ func TestTokenECDSASignedCert(t *testing.T) {
 				Config: config,
 				Check: func(s *terraform.State) error {
 					t.Log("Issuing TPP certificate with CN", data.cn)
-					return checkStandardCertPKCS8(t, &data, s)
+					return checkStandardCert(t, &data, s)
 				},
 			},
 			r.TestStep{
@@ -913,7 +911,7 @@ func TestTokenECDSASignedCert(t *testing.T) {
 				Check: func(s *terraform.State) error {
 					t.Log("Testing TPP certificate second run")
 					gotSerial := data.serial
-					err := checkStandardCertPKCS8(t, &data, s)
+					err := checkStandardCert(t, &data, s)
 					if err != nil {
 						return err
 					} else {
@@ -953,7 +951,7 @@ func TestSignedCertCustomFields(t *testing.T) {
 				Config: config,
 				Check: func(s *terraform.State) error {
 					t.Log("Issuing TPP certificate with CN", data.cn)
-					return checkStandardCertPKCS8(t, &data, s)
+					return checkStandardCert(t, &data, s)
 				},
 			},
 			r.TestStep{
@@ -961,7 +959,7 @@ func TestSignedCertCustomFields(t *testing.T) {
 				Check: func(s *terraform.State) error {
 					t.Log("Testing TPP certificate second run")
 					gotSerial := data.serial
-					err := checkStandardCertPKCS8(t, &data, s)
+					err := checkStandardCert(t, &data, s)
 					if err != nil {
 						return err
 					} else {
@@ -1051,7 +1049,7 @@ func TestTokenSignedCertValidDaysWithGreaterExpirationWindow(t *testing.T) {
 				ExpectNonEmptyPlan: true,
 				Check: func(s *terraform.State) error {
 					t.Log("Issuing TPP certificate with CN and valid days", data.cn)
-					err := checkStandardCertPKCS8(t, &data, s)
+					err := checkStandardCert(t, &data, s)
 					if err != nil {
 						return err
 					}
@@ -1097,7 +1095,7 @@ func TestTokenSignedCertUpdateSetGreaterExpWindow(t *testing.T) {
 			r.TestStep{
 				Config: config,
 				Check: func(s *terraform.State) error {
-					err := checkStandardCertPKCS8(t, &data, s)
+					err := checkStandardCert(t, &data, s)
 					if err != nil {
 						return err
 					}
@@ -1110,7 +1108,7 @@ func TestTokenSignedCertUpdateSetGreaterExpWindow(t *testing.T) {
 				Check: func(s *terraform.State) error {
 					t.Log("Testing TPP certificate update")
 					gotSerial := data.serial
-					err := checkStandardCertPKCS8(t, &data, s)
+					err := checkStandardCert(t, &data, s)
 					if err != nil {
 						return err
 					}
@@ -1149,23 +1147,7 @@ func getCustomFields(variableName string) string {
 //TODO: make test on invalid options fo RSA, ECSA keys
 //TODO: make test with too big expiration window
 
-func checkStandardCertPKCS1(t *testing.T, data *testData, s *terraform.State) error {
-	err := checkStandardCertOutputs(t, data, s, expectedPrivKeyPKCS1)
-	if err != nil {
-		return err
-	}
-	return nil
-}
-
-func checkStandardCertPKCS8(t *testing.T, data *testData, s *terraform.State) error {
-	err := checkStandardCertOutputs(t, data, s, expectedPrivKeyPKCS8)
-	if err != nil {
-		return err
-	}
-	return nil
-}
-
-func checkStandardCertOutputs(t *testing.T, data *testData, s *terraform.State, kf KeyFormat) error {
+func checkStandardCert(t *testing.T, data *testData, s *terraform.State) error {
 	t.Log("Testing certificate with cn", data.cn)
 	certUntyped := s.RootModule().Outputs["certificate"].Value
 	certificate, ok := certUntyped.(string)
@@ -1183,14 +1165,14 @@ func checkStandardCertOutputs(t *testing.T, data *testData, s *terraform.State, 
 		return fmt.Errorf("output for \"private_key\" is not a string")
 	}
 
-	err := checkStandardCertInfo(t, data, certificate, privateKey, kf)
+	err := checkStandardCertInfo(t, data, certificate, privateKey)
 	if err != nil {
 		return err
 	}
 	return nil
 }
 
-func checkStandardCertInfo(t *testing.T, data *testData, certificate string, privateKey string, kf KeyFormat) error {
+func checkStandardCertInfo(t *testing.T, data *testData, certificate string, privateKey string) error {
 	block, _ := pem.Decode([]byte(certificate))
 	cert, err := x509.ParseCertificate(block.Bytes)
 	if err != nil {
@@ -1214,18 +1196,11 @@ func checkStandardCertInfo(t *testing.T, data *testData, certificate string, pri
 
 	t.Logf("Testing private key PEM:\n %s", privateKey)
 	privKeyPEMbytes := make([]byte, 0)
-	if kf == expectedPrivKeyPKCS1 {
-		privKeyPEMbytes, err = getPrivateKey([]byte(privateKey), data.private_key_password)
-		if err != nil {
-			return fmt.Errorf("error trying to decrypt key: %s", err)
-		}
-	} else if kf == expectedPrivKeyPKCS8 {
-		privateKeyString, err := util.DecryptPkcs8PrivateKey(privateKey, data.private_key_password)
-		if err != nil {
-			return fmt.Errorf("error trying to decrypt key: %s", err)
-		}
-		privKeyPEMbytes = []byte(privateKeyString)
+	privateKeyString, err := util.DecryptPkcs8PrivateKey(privateKey, data.private_key_password)
+	if err != nil {
+		return fmt.Errorf("error trying to decrypt key: %s", err)
 	}
+	privKeyPEMbytes = []byte(privateKeyString)
 
 	_, err = tls.X509KeyPair([]byte(certificate), privKeyPEMbytes)
 	if err != nil {
@@ -1379,7 +1354,7 @@ func TestTppCsrService(t *testing.T) {
 				Config: config,
 				Check: func(s *terraform.State) error {
 					t.Log("Issuing TPP certificate with CSR Service Generated", data.cn)
-					return checkStandardCertPKCS8(t, &data, s)
+					return checkStandardCert(t, &data, s)
 				},
 			},
 		},
@@ -1403,7 +1378,7 @@ func TestVaasCsrService(t *testing.T) {
 			r.TestStep{
 				Config: config,
 				Check: func(s *terraform.State) error {
-					err := checkStandardCertPKCS8(t, &data, s)
+					err := checkStandardCert(t, &data, s)
 					if err != nil {
 						return err
 					}
@@ -1518,7 +1493,7 @@ func checkImportTppCertWithCustomFields(t *testing.T, data *testData, states []*
 func checkImportCert(t *testing.T, data *testData, attr map[string]string) error {
 	certificate := attr["certificate"]
 	privateKey := attr["private_key_pem"]
-	err := checkStandardCertInfo(t, data, certificate, privateKey, expectedPrivKeyPKCS8)
+	err := checkStandardCertInfo(t, data, certificate, privateKey)
 	if err != nil {
 		return err
 	}
@@ -1668,7 +1643,7 @@ func TestManyCertsTpp(t *testing.T) {
 				Config: config,
 				Check: func(s *terraform.State) error {
 					t.Log("Issuing TPP certificate with CN", data.cn)
-					return checkStandardCertPKCS8(t, &data, s)
+					return checkStandardCert(t, &data, s)
 				},
 			},
 			r.TestStep{
@@ -1676,7 +1651,7 @@ func TestManyCertsTpp(t *testing.T) {
 				Check: func(s *terraform.State) error {
 					t.Log("Testing TPP certificate second run")
 					gotSerial := data.serial
-					err := checkStandardCertPKCS8(t, &data, s)
+					err := checkStandardCert(t, &data, s)
 					if err != nil {
 						return err
 					} else {
@@ -1695,7 +1670,7 @@ func TestManyCertsTpp(t *testing.T) {
 				Check: func(s *terraform.State) error {
 					t.Log("Testing TPP certificate third run")
 					gotSerial := data.serial
-					err := checkStandardCertPKCS8(t, &data, s)
+					err := checkStandardCert(t, &data, s)
 					if err != nil {
 						return err
 					} else {
@@ -1714,7 +1689,7 @@ func TestManyCertsTpp(t *testing.T) {
 				Check: func(s *terraform.State) error {
 					t.Log("Testing TPP certificate fourth run")
 					gotSerial := data.serial
-					err := checkStandardCertPKCS8(t, &data, s)
+					err := checkStandardCert(t, &data, s)
 					if err != nil {
 						return err
 					} else {
@@ -1733,7 +1708,7 @@ func TestManyCertsTpp(t *testing.T) {
 				Check: func(s *terraform.State) error {
 					t.Log("Testing TPP certificate fifth run")
 					gotSerial := data.serial
-					err := checkStandardCertPKCS8(t, &data, s)
+					err := checkStandardCert(t, &data, s)
 					if err != nil {
 						return err
 					} else {
@@ -1770,7 +1745,7 @@ func TestManyCertsTppCsrService(t *testing.T) {
 				Config: config,
 				Check: func(s *terraform.State) error {
 					t.Log("Issuing TPP certificate with CN", data.cn)
-					return checkStandardCertPKCS8(t, &data, s)
+					return checkStandardCert(t, &data, s)
 				},
 			},
 			r.TestStep{
@@ -1778,7 +1753,7 @@ func TestManyCertsTppCsrService(t *testing.T) {
 				Check: func(s *terraform.State) error {
 					t.Log("Testing TPP certificate second run")
 					gotSerial := data.serial
-					err := checkStandardCertPKCS8(t, &data, s)
+					err := checkStandardCert(t, &data, s)
 					if err != nil {
 						return err
 					} else {
@@ -1797,7 +1772,7 @@ func TestManyCertsTppCsrService(t *testing.T) {
 				Check: func(s *terraform.State) error {
 					t.Log("Testing TPP certificate third run")
 					gotSerial := data.serial
-					err := checkStandardCertPKCS8(t, &data, s)
+					err := checkStandardCert(t, &data, s)
 					if err != nil {
 						return err
 					} else {
@@ -1816,7 +1791,7 @@ func TestManyCertsTppCsrService(t *testing.T) {
 				Check: func(s *terraform.State) error {
 					t.Log("Testing TPP certificate fourth run")
 					gotSerial := data.serial
-					err := checkStandardCertPKCS8(t, &data, s)
+					err := checkStandardCert(t, &data, s)
 					if err != nil {
 						return err
 					} else {
@@ -1835,7 +1810,7 @@ func TestManyCertsTppCsrService(t *testing.T) {
 				Check: func(s *terraform.State) error {
 					t.Log("Testing TPP certificate fifth run")
 					gotSerial := data.serial
-					err := checkStandardCertPKCS8(t, &data, s)
+					err := checkStandardCert(t, &data, s)
 					if err != nil {
 						return err
 					} else {
@@ -1874,7 +1849,7 @@ func TestTppSansCsrService(t *testing.T) {
 				Config: config,
 				Check: func(s *terraform.State) error {
 					t.Log("Issuing TPP certificate with CN", data.cn)
-					err := checkStandardCertPKCS8(t, &data, s)
+					err := checkStandardCert(t, &data, s)
 					if err != nil {
 						return err
 					}

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -3,10 +3,14 @@ layout: "venafi"
 page_title: "Provider: Venafi"
 sidebar_current: "docs-venafi-index"
 description: |-
-  Venafi is the enterprise platform for Machine Identity Protection. The Venafi provider streamlines the process of acquiring SSL/TLS keys and certificates from Venafi services giving assurance of compliance with Information Security policies.  It provides resources that allow private keys and certficates to be created as part of a Terraform deployment.
+Venafi is the enterprise platform for Machine Identity Protection. The Venafi provider streamlines the process of acquiring SSL/TLS keys and certificates from Venafi services giving assurance of compliance with Information Security policies.  It provides resources that allow private keys and certficates to be created as part of a Terraform deployment.
 ---
 
 # Venafi Provider
+
+!> We dropped support for RSA PKCS#1 formatted keys in version 15.0 and also for EC Keys in version 0.15.4
+(you can find out more about this transition in [here](https://github.com/Venafi/vcert/releases/tag/v4.17.0)).
+For backward compatibility during Terraform state refresh please update to version 0.15.5 or above
 
 [Venafi](https://www.venafi.com) is the enterprise platform for Machine Identity
 Protection. The Venafi provider streamlines the process of acquiring SSL/TLS
@@ -19,10 +23,10 @@ Use the navigation to the left to read about the available resources.
 ## Example Usage for Venafi as a Service
 
 You can sign up for a Venafi as a Service account by visiting https://vaas.venafi.com/.
-Once registered, find your API key by clicking your name in the top right of the web interface.  You 
-will also need to specify the `zone` to use when requesting certificates. Zones define the machine 
-identity policy that will be applied to certificate requests and the certificate authority that will 
-issue certificates. The zone is formed by combining the Application Name and Issuing Template API Alias 
+Once registered, find your API key by clicking your name in the top right of the web interface.  You
+will also need to specify the `zone` to use when requesting certificates. Zones define the machine
+identity policy that will be applied to certificate requests and the certificate authority that will
+issue certificates. The zone is formed by combining the Application Name and Issuing Template API Alias
 (e.g. "Business App\Enterprise CIT").
 
 ```hcl
@@ -47,7 +51,7 @@ to certificate requests and the certificate authority that will issue certificat
 to ask them for a root CA certificate for your `trust_bundle` if the Venafi Platform URL is secured by
 a certificate your Terraform computer does not already trust.
 
-Obtain the required `access_token` for Trust Protection Platform using the 
+Obtain the required `access_token` for Trust Protection Platform using the
 [VCert CLI](https://github.com/Venafi/vcert/blob/master/README-CLI-PLATFORM.md#obtaining-an-authorization-token)
 (`getcred action` with `--client-id "hashicorp-terraform-by-venafi"` and `--scope "certificate:manage"`) or
 the Platform's Authorize REST API method.  The *configuration:manage* scope is required to set certificate
@@ -72,8 +76,8 @@ resource "venafi_certificate" "webserver" {
 
 The following arguments are supported:
 
-* `zone` - (Required, string) Application Name and Issuing 
-Template API Alias (e.g. "Business App\Enterprise CIT") for Venafi as a Service or policy folder for Venafi Platform.
+* `zone` - (Required, string) Application Name and Issuing
+  Template API Alias (e.g. "Business App\Enterprise CIT") for Venafi as a Service or policy folder for Venafi Platform.
 
 * `url` - (Optional, string) Venafi URL (e.g. "https://tpp.venafi.example").
 
@@ -91,7 +95,7 @@ Template API Alias (e.g. "Business App\Enterprise CIT") for Venafi as a Service 
 
 ## Environment Variables
 
-The following environment variables can also be used to specify provider 
+The following environment variables can also be used to specify provider
 argument values:
 
 * VENAFI_ZONE

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -8,9 +8,9 @@ Venafi is the enterprise platform for Machine Identity Protection. The Venafi pr
 
 # Venafi Provider
 
-!> We dropped support for RSA PKCS#1 formatted keys in version 15.0 and also for EC Keys in version 0.15.4
-(you can find out more about this transition in [here](https://github.com/Venafi/vcert/releases/tag/v4.17.0)).
-For backward compatibility during Terraform state refresh please update to version 0.15.5 or above
+!> We dropped support for RSA PKCS#1 formatted keys for TLS certificates in version 15.0 and also for EC Keys in version 
+0.15.4 (you can find out more about this transition in [here](https://github.com/Venafi/vcert/releases/tag/v4.17.0)).
+For backward compatibility during Terraform state refresh please update to version 0.15.5 or above.
 
 [Venafi](https://www.venafi.com) is the enterprise platform for Machine Identity
 Protection. The Venafi provider streamlines the process of acquiring SSL/TLS

--- a/website/docs/r/venafi_certificate.html.markdown
+++ b/website/docs/r/venafi_certificate.html.markdown
@@ -8,6 +8,10 @@ Provides access to TLS key and certificate data in Venafi. This can be used to d
 
 # venafi_certificate
 
+!> We dropped support for RSA PKCS#1 formatted keys in version 15.0 and also for EC Keys in version 0.15.4
+(you can find out more about this transition in [here](https://github.com/Venafi/vcert/releases/tag/v4.17.0)).
+For backward compatibility during Terraform state refresh please update to version 0.15.5 or above
+
 Provides access to TLS key and certificate data enrolled using Venafi. This can be used to define a
 certificate.
 

--- a/website/docs/r/venafi_certificate.html.markdown
+++ b/website/docs/r/venafi_certificate.html.markdown
@@ -8,9 +8,9 @@ Provides access to TLS key and certificate data in Venafi. This can be used to d
 
 # venafi_certificate
 
-!> We dropped support for RSA PKCS#1 formatted keys in version 15.0 and also for EC Keys in version 0.15.4
-(you can find out more about this transition in [here](https://github.com/Venafi/vcert/releases/tag/v4.17.0)).
-For backward compatibility during Terraform state refresh please update to version 0.15.5 or above
+!> We dropped support for RSA PKCS#1 formatted keys for TLS certificates in version 15.0 and also for EC Keys in 
+version 0.15.4 (you can find out more about this transition in [here](https://github.com/Venafi/vcert/releases/tag/v4.17.0)).
+For backward compatibility during Terraform state refresh please update to version 0.15.5 or above.
 
 Provides access to TLS key and certificate data enrolled using Venafi. This can be used to define a
 certificate.


### PR DESCRIPTION
- Adds backward compatibility for PKCS#1 format keys during Terraform state refresh
- Removes lingering PKCS#1 codo from testing
- Adds missing warnings for drop support in previous versions (0.15.0~0.15.4)