### PR TITLE
Enhancement/exposes object name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.16.1 (Oct 7, 2022)
+Added support for nickname attribute to override certificate object name at TPP.
+Fixed a bug that would let a not valid certificate key-pair to be stored in terraform state during resource creation
+
 ## 0.16.0 (May 16, 2022)
 Upgraded plugin to SDKv2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.16.1 (Oct 7, 2022)
+## 0.16.1 (October 7, 2022)
 Added support for nickname attribute to override certificate object name at TPP.
 Fixed a bug that would let a not valid certificate key-pair to be stored in terraform state during resource creation
 

--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ for Terraform version 0.11 and below.
    Service since that variable is used by the provider to decide which Venafi product
    to use.
 
-3. Create a `venafi_certificate` resource that will generate a new key pair and
+ Create a `venafi_certificate` resource that will generate a new key pair and
    enroll the certificate needed by a "tls_server" application:
 
    ```text
@@ -214,8 +214,9 @@ for Terraform version 0.11 and below.
    >:pushpin: **NOTE**: Updating only `expiration_window` will not trigger another resource to be created by itself, thus won't enroll a new certificate. This won't apply if the expiration_window constraint allows it, this means, if time to expire of the certificate is within the expiration window.
 
    | Property            | Type          |  Description                                                                      | Default   |
-   | ------------------- | ------------- | --------------------------------------------------------------------------------- | --------- |
+   |---------------------| ------------------- |--------------------------------------------------------------------------------- | --------- |
    | `common_name`       | [String](https://www.terraform.io/docs/extend/schemas/schema-types.html#typestring) | Common name of certificate                                                        | `none` |
+   | `nickname`          | [String](https://www.terraform.io/docs/extend/schemas/schema-types.html#typestring) | Use to specify a name for the new certificate object that will be created and placed in a policy. Only valid for TPP.|`none`|
    | `san_dns`           | [List](https://www.terraform.io/docs/extend/schemas/schema-types.html#typelist) | String array of DNS names to use as alternative subjects of the certificate               | `none` |
    | `san_email`         | [List](https://www.terraform.io/docs/extend/schemas/schema-types.html#typelist) | String array of email addresses to use as alternative subjects of the certificate         | `none` |
    | `san_ip`            | [List](https://www.terraform.io/docs/extend/schemas/schema-types.html#typelist) | String array of IP addresses to use as alternative subjects of the certificate            | `none` |
@@ -225,10 +226,10 @@ for Terraform version 0.11 and below.
    | `ecdsa_curve`       | [String](https://www.terraform.io/docs/extend/schemas/schema-types.html#typestring) | ECDSA curve to use when generating a key pair (i.e. P256, P384, P521). Applies when `algorithm`=ECDSA | P521   |
    | `key_password`      | [String](https://www.terraform.io/docs/extend/schemas/schema-types.html#typestring) | Private key password                                                              | `none` |
    | `custom_fields`     | [Map](https://www.terraform.io/docs/extend/schemas/schema-types.html#typemap) | Collection of key-value pairs where the key is the name of the Custom Field in Trust Protection Platform.  For list type Custom Fields, use the \| character to delimit mulitple values.<br/>Example: `custom_fields = { "Number List" = "2\|4\|6" }` | `none` |
-   | `valid_days` | [Integer](https://www.terraform.io/docs/extend/schemas/schema-types.html#typeint) | Desired number of days for which the new certificate will be valid | `none` |
-   | `issuer_hint` | [String](https://www.terraform.io/docs/extend/schemas/schema-types.html#typestring) | Used with `valid_days` to indicate the target issuer when using Trust Protection Platform and the CA is DigiCert, Entrust, or Microsoft.<br/>Example: `issuer_hint = "Microsoft"` | `none` |
+   | `valid_days`        | [Integer](https://www.terraform.io/docs/extend/schemas/schema-types.html#typeint) | Desired number of days for which the new certificate will be valid | `none` |
+   | `issuer_hint`       | [String](https://www.terraform.io/docs/extend/schemas/schema-types.html#typestring) | Used with `valid_days` to indicate the target issuer when using Trust Protection Platform and the CA is DigiCert, Entrust, or Microsoft.<br/>Example: `issuer_hint = "Microsoft"` | `none` |
    | `expiration_window` | [Integer](https://www.terraform.io/docs/extend/schemas/schema-types.html#typeint) | Number of hours before certificate expiry to request a new certificate            | 168    |
-   | `csr_origin` | [String](https://www.terraform.io/docs/extend/schemas/schema-types.html#typestring) | Option to decide whether key-pair generation will be `local` or `service` generated | `local` |
+   | `csr_origin`        | [String](https://www.terraform.io/docs/extend/schemas/schema-types.html#typestring) | Option to decide whether key-pair generation will be `local` or `service` generated | `local` |
 
    >:pushpin: **NOTE**: The `venafi_certificate` resource handles certificate
    renewals as long as a `terraform apply` is done within the `expiration_window`
@@ -245,7 +246,7 @@ for Terraform version 0.11 and below.
    | `certificate`     | [String](https://www.terraform.io/docs/extend/schemas/schema-types.html#typestring) | End-entity certificate in PEM format |
    | `pkcs12`          | [String](https://www.terraform.io/docs/extend/schemas/schema-types.html#typestring) | Base64-encoded PKCS#12 keystore encrypted using `key_password`, if specified. Useful when working with resources like [azurerm_key_vault_certificate](https://www.terraform.io/docs/providers/azurerm/r/key_vault_certificate.html). Base64 decode to obtain file bytes. |
 
-4. For verification purposes, output the certificate, private key, and
+5. For verification purposes, output the certificate, private key, and
    chain in PEM format and as a PKCS#12 keystore (base64-encoded):
 
    ```text
@@ -267,7 +268,7 @@ for Terraform version 0.11 and below.
    }
    ```
 
-5. Execute `terraform init`, `terraform plan`, `terraform apply`, and finally
+6. Execute `terraform init`, `terraform plan`, `terraform apply`, and finally
    `terraform show` from the directory containing the configuration file.
 
 ### Importing
@@ -285,7 +286,9 @@ The `id` for each platform is:
 
 **TPP:**
 
-The `common name` of the certificate, internally we built the `pickup_id` using the `zone` defined at the provider block.
+The `nickname` of the certificate, which represents the name of the certificate object in TPP. Internally we built the `pickup_id` using the `zone` defined at the provider block.
+
+>:pushpin: **NOTE**: The certificate object name at TPP, usually, should be the same as the `common_name` provided as it is considered good practice, but the `nickname` actually could differ from the common name, as there some use cases whenever you want to handle certificates with different nicknames. For example, you could have certificates with same common name and different SANs, then, you could manage many certificate resources that share the same common name using `for_each` and `count` meta arguments.
 
 **VaaS:**
 
@@ -381,7 +384,7 @@ terraform import "venafi_certificate.imported_certificate" "xxxxxxxx-xxxx-xxxx-x
    The `venafi_ssh_certificate` resource has the following options, which only `key_id` and `template` are required:
 
    | Property              | Type          |  Description                                                                      | Default   |
------------------------| ------------------- | ------------- | --------------------------------------------------------------------------------- | --------- |
+   | ------------------- | ------------- | --------------------------------------------------------------------------------- | --------- |
    | `key_id`              |[String](https://www.terraform.io/docs/extend/schemas/schema-types.html#typestring) |The identifier of the requested certificate|`none`|
    | `template`            |[String](https://www.terraform.io/docs/extend/schemas/schema-types.html#typestring)|The certificate issuing template|`none`|
    | `key_passphrase`      |[String](https://www.terraform.io/docs/extend/schemas/schema-types.html#typestring)|Passphrase for encrypting the private key|`none`|
@@ -390,7 +393,7 @@ terraform import "venafi_certificate.imported_certificate" "xxxxxxxx-xxxx-xxxx-x
    | `key_size`            |[Int](https://www.terraform.io/docs/extend/schemas/schema-types.html#typeint)|The key size bits, they will be used for creating keypair|`3072`|
    | `windows`             |[Bool](https://www.terraform.io/docs/extend/schemas/schema-types.html#typebool)|Output certificate and key files in Windows format (i.e. with \r\n line endings) instead of Unix format (i.e. \n line endings).|`false`|
    | `valid_hours`         |[Int](https://www.terraform.io/docs/extend/schemas/schema-types.html#typeint)|How much time the requester wants to have the certificate valid, the format is hours|`none`|
-   | `nickname`            |[String](https://www.terraform.io/docs/extend/schemas/schema-types.html#typestring) |The friendly name for the certificate object. If not specified, the value of the `key_id` is used.|`none`|
+   | `object_name`         |[String](https://www.terraform.io/docs/extend/schemas/schema-types.html#typestring) |The friendly name for the certificate object. If not specified, the value of the `key_id` is used.|`none`|
    | `public_key`          |[String](https://www.terraform.io/docs/extend/schemas/schema-types.html#typestring)|The path of the public key that will be used to generate the certificate if `public_key_method` set to `file`|`none`|
    | `public_key_method`   |[String](https://www.terraform.io/docs/extend/schemas/schema-types.html#typestring) | If the public key will be: `local` or `service` generated or `file` provided|`local`|
    | `principal`           |[List](https://www.terraform.io/docs/extend/schemas/schema-types.html#typelist)|**[DEPRECATED]** This will be removed in the future. Use `principals` instead. The requested principals|`none`|

--- a/README.md
+++ b/README.md
@@ -380,24 +380,24 @@ terraform import "venafi_certificate.imported_certificate" "xxxxxxxx-xxxx-xxxx-x
 
    The `venafi_ssh_certificate` resource has the following options, which only `key_id` and `template` are required:
 
-   | Property            | Type          |  Description                                                                      | Default   |
-   | ------------------- | ------------- | --------------------------------------------------------------------------------- | --------- |
-   |`key_id`|[String](https://www.terraform.io/docs/extend/schemas/schema-types.html#typestring) |The identifier of the requested certificate|`none`|
-   |`template`|[String](https://www.terraform.io/docs/extend/schemas/schema-types.html#typestring)|The certificate issuing template|`none`|
-   |`key_passphrase`|[String](https://www.terraform.io/docs/extend/schemas/schema-types.html#typestring)|Passphrase for encrypting the private key|`none`|
-   |`folder`|[String](https://www.terraform.io/docs/extend/schemas/schema-types.html#typestring) |The DN of the policy folder where the certificate object will be created. It will overwrite the default folder set at the template |`none`|
-   |`force_command`|[String](https://www.terraform.io/docs/extend/schemas/schema-types.html#typestring)|The requested force command|`none`|
-   |`key_size`|[Int](https://www.terraform.io/docs/extend/schemas/schema-types.html#typeint)|The key size bits, they will be used for creating keypair|`3072`|
-   |`windows`|[Bool](https://www.terraform.io/docs/extend/schemas/schema-types.html#typebool)|Output certificate and key files in Windows format (i.e. with \r\n line endings) instead of Unix format (i.e. \n line endings).|`false`|
-   |`valid_hours`|[Int](https://www.terraform.io/docs/extend/schemas/schema-types.html#typeint)|How much time the requester wants to have the certificate valid, the format is hours|`none`|
-   |`object_name`|[String](https://www.terraform.io/docs/extend/schemas/schema-types.html#typestring) |The friendly name for the certificate object. If not specified, the value of the `key_id` is used.|`none`|
-   |`public_key`|[String](https://www.terraform.io/docs/extend/schemas/schema-types.html#typestring)|The path of the public key that will be used to generate the certificate if `public_key_method` set to `file`|`none`|
-   |`public_key_method`|[String](https://www.terraform.io/docs/extend/schemas/schema-types.html#typestring) | If the public key will be: `local` or `service` generated or `file` provided|`local`|
-   |`principal` |[List](https://www.terraform.io/docs/extend/schemas/schema-types.html#typelist)|**[DEPRECATED]** This will be removed in the future. Use `principals` instead. The requested principals|`none`|
-   |`principals`|[List](https://www.terraform.io/docs/extend/schemas/schema-types.html#typelist)|The requested principals|`none`|
-   |`source_address`|[List](https://www.terraform.io/docs/extend/schemas/schema-types.html#typelist)|The requested source addresses as list of IP/CIDR|`none`|
-   |`destination_address`|[List](https://www.terraform.io/docs/extend/schemas/schema-types.html#typelist)|The address (FQDN/hostname/IP/CIDR) of the destination host where the certificate will be used for authentication. Applicable for client certificates and is used for reporting/auditing only.|`none`|
-   |`extension`|[List](https://www.terraform.io/docs/extend/schemas/schema-types.html#typelist)|The requested certificate extensions|`none`|
+   | Property              | Type          |  Description                                                                      | Default   |
+-----------------------| ------------------- | ------------- | --------------------------------------------------------------------------------- | --------- |
+   | `key_id`              |[String](https://www.terraform.io/docs/extend/schemas/schema-types.html#typestring) |The identifier of the requested certificate|`none`|
+   | `template`            |[String](https://www.terraform.io/docs/extend/schemas/schema-types.html#typestring)|The certificate issuing template|`none`|
+   | `key_passphrase`      |[String](https://www.terraform.io/docs/extend/schemas/schema-types.html#typestring)|Passphrase for encrypting the private key|`none`|
+   | `folder`              |[String](https://www.terraform.io/docs/extend/schemas/schema-types.html#typestring) |The DN of the policy folder where the certificate object will be created. It will overwrite the default folder set at the template |`none`|
+   | `force_command`       |[String](https://www.terraform.io/docs/extend/schemas/schema-types.html#typestring)|The requested force command|`none`|
+   | `key_size`            |[Int](https://www.terraform.io/docs/extend/schemas/schema-types.html#typeint)|The key size bits, they will be used for creating keypair|`3072`|
+   | `windows`             |[Bool](https://www.terraform.io/docs/extend/schemas/schema-types.html#typebool)|Output certificate and key files in Windows format (i.e. with \r\n line endings) instead of Unix format (i.e. \n line endings).|`false`|
+   | `valid_hours`         |[Int](https://www.terraform.io/docs/extend/schemas/schema-types.html#typeint)|How much time the requester wants to have the certificate valid, the format is hours|`none`|
+   | `nickname`            |[String](https://www.terraform.io/docs/extend/schemas/schema-types.html#typestring) |The friendly name for the certificate object. If not specified, the value of the `key_id` is used.|`none`|
+   | `public_key`          |[String](https://www.terraform.io/docs/extend/schemas/schema-types.html#typestring)|The path of the public key that will be used to generate the certificate if `public_key_method` set to `file`|`none`|
+   | `public_key_method`   |[String](https://www.terraform.io/docs/extend/schemas/schema-types.html#typestring) | If the public key will be: `local` or `service` generated or `file` provided|`local`|
+   | `principal`           |[List](https://www.terraform.io/docs/extend/schemas/schema-types.html#typelist)|**[DEPRECATED]** This will be removed in the future. Use `principals` instead. The requested principals|`none`|
+   | `principals`          |[List](https://www.terraform.io/docs/extend/schemas/schema-types.html#typelist)|The requested principals|`none`|
+   | `source_address`      |[List](https://www.terraform.io/docs/extend/schemas/schema-types.html#typelist)|The requested source addresses as list of IP/CIDR|`none`|
+   | `destination_address` |[List](https://www.terraform.io/docs/extend/schemas/schema-types.html#typelist)|The address (FQDN/hostname/IP/CIDR) of the destination host where the certificate will be used for authentication. Applicable for client certificates and is used for reporting/auditing only.|`none`|
+   | `extension`           |[List](https://www.terraform.io/docs/extend/schemas/schema-types.html#typelist)|The requested certificate extensions|`none`|
 
 3. Create a resource `venafi_ssh_config` that will hold configuration needed by a remote host:
 

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/terraform-providers/terraform-provider-venafi
 go 1.12
 
 require (
-	github.com/Venafi/vcert/v4 v4.19.0
+	github.com/Venafi/vcert/v4 v4.22.0
 	github.com/client9/misspell v0.3.4
 	github.com/golangci/golangci-lint v1.21.0
 	github.com/hashicorp/terraform-plugin-log v0.3.0

--- a/go.sum
+++ b/go.sum
@@ -23,8 +23,8 @@ github.com/OpenPeeDeeP/depguard v1.0.1/go.mod h1:xsIw86fROiiwelg+jB2uM9PiKihMMmU
 github.com/ProtonMail/go-crypto v0.0.0-20210428141323-04723f9f07d7 h1:YoJbenK9C67SkzkDfmQuVln04ygHj3vjZfd9FL+GmQQ=
 github.com/ProtonMail/go-crypto v0.0.0-20210428141323-04723f9f07d7/go.mod h1:z4/9nQmJSSwwds7ejkxaJwO37dru3geImFUdJlaLzQo=
 github.com/StackExchange/wmi v0.0.0-20180116203802-5d049714c4a6/go.mod h1:3eOhrUMpNV+6aFIbp5/iudMxNCF27Vw2OZgy4xEx0Fg=
-github.com/Venafi/vcert/v4 v4.19.0 h1:/zIl9+s6uIjtI/LazPplrcSgThbwJkUx1XbyET3u8Iw=
-github.com/Venafi/vcert/v4 v4.19.0/go.mod h1:VcojF47VAzBnYHSRrb0SwOCmMpWJczajTuPiZNDJJSo=
+github.com/Venafi/vcert/v4 v4.22.0 h1:trH5eftOQ3cKgGFenMGFZ62yfITeunOSF9zx2xpZ1g8=
+github.com/Venafi/vcert/v4 v4.22.0/go.mod h1:4Nec3twWisOdS1unpDZ93sfau9eVSDS8Ot+Ry/gg0es=
 github.com/acomagu/bufpipe v1.0.3 h1:fxAGrHZTgQ9w5QqVItgzwj235/uYZYgbXitB+dLupOk=
 github.com/acomagu/bufpipe v1.0.3/go.mod h1:mxdxdup/WdsKVreO5GpW4+M/1CE2sMG4jeGJ2sYmHc4=
 github.com/agext/levenshtein v1.2.1/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=

--- a/venafi/resource_venafi_certificate.go
+++ b/venafi/resource_venafi_certificate.go
@@ -39,6 +39,11 @@ const (
 	terraformStateTainted      = "terraform state was modified by another party"
 )
 
+// Started work to make resource attribute less error-prone
+const (
+	venafiCertificateAttrNickname = "nickname"
+)
+
 func resourceVenafiCertificate() *schema.Resource {
 	return &schema.Resource{
 		CreateContext: resourceVenafiCertificateCreate,
@@ -60,7 +65,7 @@ func resourceVenafiCertificate() *schema.Resource {
 				Description: "Common name of certificate",
 				ForceNew:    true,
 			},
-			"object_name": &schema.Schema{
+			venafiCertificateAttrNickname: &schema.Schema{
 				Type:        schema.TypeString,
 				Optional:    true,
 				Description: "Use to specify a name for the new certificate object that will be created and placed in a policy. Only valid for TPP",
@@ -498,7 +503,7 @@ func enrollVenafiCertificate(ctx context.Context, d *schema.ResourceData, cl end
 		req.DNSNames = append(req.DNSNames, commonName)
 	}
 	if cl.GetType() == endpoint.ConnectorTypeTPP {
-		friendlyName := d.Get("object_name").(string)
+		friendlyName := d.Get(venafiCertificateAttrNickname).(string)
 		if friendlyName != "" {
 			req.FriendlyName = friendlyName
 		}
@@ -967,8 +972,8 @@ func fillSchemaPropertiesImport(d *schema.ResourceData, data *certificate.PEMCol
 		// only TPP handle the concept of object name so only then we set it
 		// we are expecting "id" have something like \\VED\\Policy\\MyPolicy\\my-object-name
 		certificateDNsplit := strings.Split(id, "\\")
-		objectName := certificateDNsplit[len(certificateDNsplit)-1]
-		err = d.Set("object_name", objectName)
+		nickname := certificateDNsplit[len(certificateDNsplit)-1]
+		err = d.Set(venafiCertificateAttrNickname, nickname)
 		if err != nil {
 			return err
 		}

--- a/venafi/resource_venafi_certificate.go
+++ b/venafi/resource_venafi_certificate.go
@@ -965,8 +965,10 @@ func fillSchemaPropertiesImport(d *schema.ResourceData, data *certificate.PEMCol
 
 	if c == endpoint.ConnectorTypeTPP {
 		// only TPP handle the concept of object name so only then we set it
-		lastSlash := strings.LastIndex(id, "\\")
-		err = d.Set("object_name", lastSlash)
+		// we are expecting "id" have something like \\VED\\Policy\\MyPolicy\\my-object-name
+		certificateDNsplit := strings.Split(id, "\\")
+		objectName := certificateDNsplit[len(certificateDNsplit)-1]
+		err = d.Set("object_name", objectName)
 		if err != nil {
 			return err
 		}

--- a/venafi/resource_venafi_certificate.go
+++ b/venafi/resource_venafi_certificate.go
@@ -769,7 +769,7 @@ func AsPKCS12(certificate string, privateKey string, chain []string, keyPassword
 }
 
 func resourceVenafiCertificateImport(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
-	time.Sleep(10 * time.Second)
+
 	id := d.Id()
 
 	if id == "" {

--- a/venafi/resource_venafi_certificate.go
+++ b/venafi/resource_venafi_certificate.go
@@ -60,6 +60,12 @@ func resourceVenafiCertificate() *schema.Resource {
 				Description: "Common name of certificate",
 				ForceNew:    true,
 			},
+			"object_name": &schema.Schema{
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Use to specify a name for the new certificate object that will be created and placed in a policy. Only valid for TPP",
+				ForceNew:    true,
+			},
 			"algorithm": &schema.Schema{
 				Type:        schema.TypeString,
 				Optional:    true,
@@ -302,26 +308,13 @@ func resourceVenafiCertificateRead(ctx context.Context, d *schema.ResourceData, 
 		return diag.FromErr(fmt.Errorf("error parsing cert: %s", err))
 	}
 	//Checking Private Key
-	var pk8PEMBytes []byte
-	var pk1PEMBytes []byte
-	if pkUntyped, ok := d.GetOk("private_key_pem"); ok {
-		pk8PEM, err := util.DecryptPkcs8PrivateKey(pkUntyped.(string), d.Get("key_password").(string))
-		if err != nil {
-			pk1PEMBytes, err = getPrivateKey([]byte(pkUntyped.(string)), d.Get("key_password").(string))
-			if err != nil {
-				return diag.FromErr(err)
-			}
-		}
-		pk8PEMBytes = []byte(pk8PEM)
-	} else {
-		return diag.FromErr(fmt.Errorf("error getting key"))
+	var privateKey string
+	if privateKeyUntyped, ok := d.GetOk("private_key_pem"); ok {
+		privateKey = privateKeyUntyped.(string)
 	}
-	_, err = tls.X509KeyPair([]byte(certPEM), pk8PEMBytes)
+	err = verifyCertKeyPair(certPEM, privateKey, keyPassword)
 	if err != nil {
-		_, err = tls.X509KeyPair([]byte(certPEM), pk1PEMBytes)
-		if err != nil {
-			return diag.FromErr(fmt.Errorf("error comparing certificate and key: %s", err))
-		}
+		diag.FromErr(err)
 	}
 
 	renewRequired := checkForRenew(*cert, d.Get("expiration_window").(int))
@@ -365,6 +358,34 @@ func resourceVenafiCertificateUpdate(ctx context.Context, d *schema.ResourceData
 func resourceVenafiCertificateDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	// We don't support deletion for created certificates from TPP, so we just remove it from state
 	d.SetId("")
+	return nil
+}
+
+func verifyCertKeyPair(certPEM string, privateKeyPEM string, keyPassword string) error {
+	var pk8PEMBytes []byte
+	var pk1PEMBytes []byte
+
+	pk8PEM, err := util.DecryptPkcs8PrivateKey(privateKeyPEM, keyPassword)
+	if err != nil {
+		pk1PEMBytes, err = getPrivateKey([]byte(privateKeyPEM), keyPassword)
+		if err != nil {
+			return err
+		}
+	}
+	pk8PEMBytes = []byte(pk8PEM)
+	if err != nil {
+		return fmt.Errorf("error getting key")
+	}
+	_, err = tls.X509KeyPair([]byte(certPEM), pk8PEMBytes)
+	if err != nil {
+		if len(pk1PEMBytes) != 0 {
+			_, err = tls.X509KeyPair([]byte(certPEM), pk1PEMBytes)
+			if err != nil {
+				return fmt.Errorf("error comparing certificate and key: %s", err)
+			}
+		}
+		return fmt.Errorf("error comparing certificate and key: %s", err)
+	}
 	return nil
 }
 
@@ -475,6 +496,12 @@ func enrollVenafiCertificate(ctx context.Context, d *schema.ResourceData, cl end
 	if !sliceContains(req.DNSNames, commonName) {
 		tflog.Info(ctx, fmt.Sprintf("Adding CN %s to SAN %s because it wasn't included.", commonName, req.DNSNames))
 		req.DNSNames = append(req.DNSNames, commonName)
+	}
+	if cl.GetType() == endpoint.ConnectorTypeTPP {
+		friendlyName := d.Get("object_name").(string)
+		if friendlyName != "" {
+			req.FriendlyName = friendlyName
+		}
 	}
 
 	//Obtain a certificate from the Venafi server
@@ -631,6 +658,14 @@ func enrollVenafiCertificate(ctx context.Context, d *schema.ResourceData, cl end
 			return err
 		}
 	}
+
+	KeyPassword := d.Get("key_password").(string)
+	tflog.Info(ctx, "Creating certificate resource: Verifying certificate key-pair")
+	err = verifyCertKeyPair(pcc.Certificate, pcc.PrivateKey, KeyPassword)
+	if err != nil {
+		return fmt.Errorf(fmt.Sprintf("Could not add certificate resource to state. Certificate and private key mismatch. Err: %s", err.Error()))
+	}
+
 	if err = d.Set("certificate", pcc.Certificate); err != nil {
 		return fmt.Errorf("Error setting certificate: %s", err)
 	}
@@ -643,8 +678,6 @@ func enrollVenafiCertificate(ctx context.Context, d *schema.ResourceData, cl end
 
 	d.SetId(req.PickupID)
 	tflog.Info(ctx, "Setting up private key")
-
-	KeyPassword := d.Get("key_password").(string)
 
 	privKey, err := util.DecryptPkcs8PrivateKey(pcc.PrivateKey, KeyPassword)
 	if err != nil {
@@ -736,6 +769,7 @@ func AsPKCS12(certificate string, privateKey string, chain []string, keyPassword
 }
 
 func resourceVenafiCertificateImport(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	time.Sleep(10 * time.Second)
 	id := d.Id()
 
 	if id == "" {
@@ -930,6 +964,13 @@ func fillSchemaPropertiesImport(d *schema.ResourceData, data *certificate.PEMCol
 	}
 
 	if c == endpoint.ConnectorTypeTPP {
+		// only TPP handle the concept of object name so only then we set it
+		lastSlash := strings.LastIndex(id, "\\")
+		err = d.Set("object_name", lastSlash)
+		if err != nil {
+			return err
+		}
+
 		customFields := certMetadata.CustomFields
 		newCustomFields := make(map[string]interface{})
 		for _, customField := range customFields {

--- a/venafi/resource_venafi_certificate_test.go
+++ b/venafi/resource_venafi_certificate_test.go
@@ -180,12 +180,12 @@ output "private_key" {
 	value = "${venafi_certificate.tpp_certificate.private_key_pem}"
 	sensitive = true
 }`
-	tppConfigWithObjectName = `
+	tppConfigWithNickname = `
 %s
 resource "venafi_certificate" "tpp_certificate" {
 	provider = "venafi.tpp"
 	common_name = "%s"
-    ${venafiCertificateAttrNickname} = "%s"
+    nickname = "%s"
 	san_dns = [
 		"%s"
 	]
@@ -697,7 +697,7 @@ func TestTPPSignedCert(t *testing.T) {
 	})
 }
 
-func TestTPPSignedCertWithObjectName(t *testing.T) {
+func TestTPPSignedCertWithNickname(t *testing.T) {
 	data := testData{}
 	rand := randSeq(9)
 	domain := "venafi.example.com"
@@ -709,7 +709,7 @@ func TestTPPSignedCertWithObjectName(t *testing.T) {
 	data.private_key_password = "FooB4rNew4$x"
 	data.key_algo = rsa2048
 	data.expiration_window = 168
-	config := fmt.Sprintf(tppConfigWithObjectName, tppProvider, data.cn, data.nickname, data.dns_ns, data.dns_ip, data.dns_email, data.key_algo, data.private_key_password, data.expiration_window)
+	config := fmt.Sprintf(tppConfigWithNickname, tppProvider, data.cn, data.nickname, data.dns_ns, data.dns_ip, data.dns_email, data.key_algo, data.private_key_password, data.expiration_window)
 	t.Logf("Testing TPP certificate with RSA key with config:\n %s", config)
 	resource.Test(t, resource.TestCase{
 		ProviderFactories: testAccProviderFactories,
@@ -1233,7 +1233,7 @@ func TestImportCertificateTpp(t *testing.T) {
 	})
 }
 
-func TestImportCertificateTppWithObjectName(t *testing.T) {
+func TestImportCertificateTppWithNickname(t *testing.T) {
 	var cfg = &vcert.Config{
 		ConnectorType: endpoint.ConnectorTypeTPP,
 	}

--- a/venafi/resource_venafi_certificate_test.go
+++ b/venafi/resource_venafi_certificate_test.go
@@ -185,7 +185,7 @@ output "private_key" {
 resource "venafi_certificate" "tpp_certificate" {
 	provider = "venafi.tpp"
 	common_name = "%s"
-    object_name = "%s"
+    ${venafiCertificateAttrNickname} = "%s"
 	san_dns = [
 		"%s"
 	]
@@ -702,14 +702,14 @@ func TestTPPSignedCertWithObjectName(t *testing.T) {
 	rand := randSeq(9)
 	domain := "venafi.example.com"
 	data.cn = rand + "." + domain
-	data.object_name = data.cn + " - 1"
+	data.nickname = data.cn + " - 1"
 	data.dns_ns = "alt-" + data.cn
 	data.dns_ip = "192.168.1.1"
 	data.dns_email = "venafi@example.com"
 	data.private_key_password = "FooB4rNew4$x"
 	data.key_algo = rsa2048
 	data.expiration_window = 168
-	config := fmt.Sprintf(tppConfigWithObjectName, tppProvider, data.cn, data.object_name, data.dns_ns, data.dns_ip, data.dns_email, data.key_algo, data.private_key_password, data.expiration_window)
+	config := fmt.Sprintf(tppConfigWithObjectName, tppProvider, data.cn, data.nickname, data.dns_ns, data.dns_ip, data.dns_email, data.key_algo, data.private_key_password, data.expiration_window)
 	t.Logf("Testing TPP certificate with RSA key with config:\n %s", config)
 	resource.Test(t, resource.TestCase{
 		ProviderFactories: testAccProviderFactories,
@@ -718,7 +718,7 @@ func TestTPPSignedCertWithObjectName(t *testing.T) {
 				Config: config,
 				Check: resource.ComposeTestCheckFunc(
 					checkStandardCertNew("venafi_certificate.tpp_certificate", t, &data),
-					resource.TestCheckResourceAttr("venafi_certificate.tpp_certificate", "object_name", data.object_name),
+					resource.TestCheckResourceAttr("venafi_certificate.tpp_certificate", venafiCertificateAttrNickname, data.nickname),
 				),
 			},
 		},
@@ -1241,7 +1241,7 @@ func TestImportCertificateTppWithObjectName(t *testing.T) {
 	rand := randSeq(9)
 	domain := "venafi.example.com"
 	data.cn = rand + "." + domain
-	data.object_name = data.cn + " - 1"
+	data.nickname = data.cn + " - 1"
 	data.private_key_password = "FooB4rNew4$x"
 	data.key_algo = rsa2048
 	data.dns_ns = "alt-" + data.cn
@@ -1252,7 +1252,7 @@ func TestImportCertificateTppWithObjectName(t *testing.T) {
 	createCertificate(t, cfg, &data, serviceGeneratedCSR)
 
 	config := fmt.Sprintf(tppCsrServiceConfigImport, tppTokenProviderImport)
-	importId := fmt.Sprintf("%s,%s", data.object_name, data.private_key_password)
+	importId := fmt.Sprintf("%s,%s", data.nickname, data.private_key_password)
 	t.Logf("Testing importing TPP cert:\n %s", config)
 	resource.Test(t, resource.TestCase{
 		ProviderFactories: testAccProviderFactories,

--- a/venafi/resource_venafi_certificate_test.go
+++ b/venafi/resource_venafi_certificate_test.go
@@ -4,6 +4,8 @@ import (
 	"crypto/x509"
 	"encoding/pem"
 	"fmt"
+	"github.com/Venafi/vcert/v4"
+	"github.com/Venafi/vcert/v4/pkg/endpoint"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"os"
@@ -177,6 +179,25 @@ output "certificate" {
 output "private_key" {
 	value = "${venafi_certificate.tpp_certificate.private_key_pem}"
 	sensitive = true
+}`
+	tppConfigWithObjectName = `
+%s
+resource "venafi_certificate" "tpp_certificate" {
+	provider = "venafi.tpp"
+	common_name = "%s"
+    object_name = "%s"
+	san_dns = [
+		"%s"
+	]
+	san_ip = [
+		"%s"
+	]
+	san_email = [
+		"%s"
+	]
+	%s
+	key_password = "%s"
+	expiration_window = %d
 }`
 	tokenConfig = `
 %s
@@ -671,6 +692,34 @@ func TestTPPSignedCert(t *testing.T) {
 						}
 					}
 				},
+			},
+		},
+	})
+}
+
+func TestTPPSignedCertWithObjectName(t *testing.T) {
+	data := testData{}
+	rand := randSeq(9)
+	domain := "venafi.example.com"
+	data.cn = rand + "." + domain
+	data.object_name = data.cn + " - 1"
+	data.dns_ns = "alt-" + data.cn
+	data.dns_ip = "192.168.1.1"
+	data.dns_email = "venafi@example.com"
+	data.private_key_password = "FooB4rNew4$x"
+	data.key_algo = rsa2048
+	data.expiration_window = 168
+	config := fmt.Sprintf(tppConfigWithObjectName, tppProvider, data.cn, data.object_name, data.dns_ns, data.dns_ip, data.dns_email, data.key_algo, data.private_key_password, data.expiration_window)
+	t.Logf("Testing TPP certificate with RSA key with config:\n %s", config)
+	resource.Test(t, resource.TestCase{
+		ProviderFactories: testAccProviderFactories,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					checkStandardCertNew("venafi_certificate.tpp_certificate", t, &data),
+					resource.TestCheckResourceAttr("venafi_certificate.tpp_certificate", "object_name", data.object_name),
+				),
 			},
 		},
 	})
@@ -1178,6 +1227,44 @@ func TestImportCertificateTpp(t *testing.T) {
 				ImportStateCheck: func(states []*terraform.InstanceState) error {
 					t.Log("Importing TPP certificate with CSR Service Generated", data.cn)
 					return checkStandardImportCert(t, data, states)
+				},
+			},
+		},
+	})
+}
+
+func TestImportCertificateTppWithObjectName(t *testing.T) {
+	var cfg = &vcert.Config{
+		ConnectorType: endpoint.ConnectorTypeTPP,
+	}
+	data := testData{}
+	rand := randSeq(9)
+	domain := "venafi.example.com"
+	data.cn = rand + "." + domain
+	data.object_name = data.cn + " - 1"
+	data.private_key_password = "FooB4rNew4$x"
+	data.key_algo = rsa2048
+	data.dns_ns = "alt-" + data.cn
+	data.dns_ip = "192.168.1.1"
+	data.dns_email = "venafi@example.com"
+	data.expiration_window = 100
+	serviceGeneratedCSR := true
+	createCertificate(t, cfg, &data, serviceGeneratedCSR)
+
+	config := fmt.Sprintf(tppCsrServiceConfigImport, tppTokenProviderImport)
+	importId := fmt.Sprintf("%s,%s", data.object_name, data.private_key_password)
+	t.Logf("Testing importing TPP cert:\n %s", config)
+	resource.Test(t, resource.TestCase{
+		ProviderFactories: testAccProviderFactories,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config:        config,
+				ResourceName:  "venafi_certificate.token_tpp_certificate_import",
+				ImportStateId: importId,
+				ImportState:   true,
+				ImportStateCheck: func(states []*terraform.InstanceState) error {
+					t.Log("Importing TPP certificate with CSR Service Generated", data.cn)
+					return checkImportWithObjectName(t, &data, states)
 				},
 			},
 		},

--- a/venafi/test_util.go
+++ b/venafi/test_util.go
@@ -375,6 +375,9 @@ func createCertificate(t *testing.T, cfg *vcert.Config, data *testData, serviceG
 	}
 	cfg.Credentials = auth
 	client, err := vcert.NewClient(cfg)
+	if err != nil {
+		t.Fatalf("Error building VCert client %s", err.Error())
+	}
 	// here stops
 	zoneConfig, err := client.ReadZoneConfiguration()
 	if err != nil {
@@ -382,10 +385,10 @@ func createCertificate(t *testing.T, cfg *vcert.Config, data *testData, serviceG
 	}
 	req := &certificate.Request{}
 	if data.object_name != "" && cfg.ConnectorType == endpoint.ConnectorTypeTPP {
-		t.Log(fmt.Sprintf("Certificate: %s", data.object_name))
+		t.Logf("Certificate: %s", data.object_name)
 	} else {
 		//at least cn mus be set for TPP
-		t.Log(fmt.Sprintf("Certificate: %s", data.cn))
+		t.Logf("Certificate: %s", data.cn)
 	}
 	if data.cn != "" {
 		req.Subject.CommonName = data.cn
@@ -410,7 +413,7 @@ func createCertificate(t *testing.T, cfg *vcert.Config, data *testData, serviceG
 	}
 	req.IssuerHint = issuerHint
 	req.CsrOrigin = certificate.LocalGeneratedCSR
-	if serviceGenerated == true {
+	if serviceGenerated {
 		req.CsrOrigin = certificate.ServiceGeneratedCSR
 	}
 	err = client.GenerateRequest(zoneConfig, req)
@@ -426,10 +429,10 @@ func createCertificate(t *testing.T, cfg *vcert.Config, data *testData, serviceG
 	req.PickupID = pickupID
 	req.ChainOption = certificate.ChainOptionRootLast
 
-	pcc, _ := certificate.NewPEMCollection(nil, nil, nil)
+	var pcc *certificate.PEMCollection
 	startTime := time.Now()
 	for {
-		if serviceGenerated == true {
+		if serviceGenerated {
 			req.Timeout = 180 * time.Second
 			req.KeyPassword = data.private_key_password
 			if cfg.ConnectorType == endpoint.ConnectorTypeTPP {

--- a/venafi/test_util.go
+++ b/venafi/test_util.go
@@ -11,6 +11,7 @@ import (
 	"github.com/Venafi/vcert/v4/pkg/util"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"io/ioutil"
 	"math/rand"
 	"os"
 	"path"
@@ -367,7 +368,12 @@ func createCertificate(t *testing.T, cfg *vcert.Config, data *testData, serviceG
 	if cfg.ConnectorType == endpoint.ConnectorTypeTPP {
 		cfg.BaseUrl = os.Getenv("TPP_URL")
 		cfg.Zone = os.Getenv("TPP_ZONE")
-		cfg.ConnectionTrust = os.Getenv("TRUST_BUNDLE")
+		trustBundlePath := os.Getenv("TRUST_BUNDLE")
+		trustBundleBytes, err := ioutil.ReadFile(trustBundlePath)
+		if err != nil {
+			t.Fatalf("Error opening trust bundle file: %s", err.Error())
+		}
+		cfg.ConnectionTrust = string(trustBundleBytes)
 		auth.AccessToken = os.Getenv("TPP_ACCESS_TOKEN")
 	} else if cfg.ConnectorType == endpoint.ConnectorTypeCloud {
 		cfg.BaseUrl = os.Getenv("CLOUD_URL")

--- a/venafi/test_util.go
+++ b/venafi/test_util.go
@@ -367,6 +367,7 @@ func createCertificate(t *testing.T, cfg *vcert.Config, data *testData, serviceG
 	if cfg.ConnectorType == endpoint.ConnectorTypeTPP {
 		cfg.BaseUrl = os.Getenv("TPP_URL")
 		cfg.Zone = os.Getenv("TPP_ZONE")
+		cfg.ConnectionTrust = os.Getenv("TRUST_BUNDLE")
 		auth.AccessToken = os.Getenv("TPP_ACCESS_TOKEN")
 	} else if cfg.ConnectorType == endpoint.ConnectorTypeCloud {
 		cfg.BaseUrl = os.Getenv("CLOUD_URL")

--- a/venafi/test_util.go
+++ b/venafi/test_util.go
@@ -318,9 +318,9 @@ func checkImportWithObjectName(t *testing.T, data *testData, states []*terraform
 	if err != nil {
 		return err
 	}
-	objectName := attributes["object_name"]
-	if objectName != data.object_name {
-		return fmt.Errorf("object name in imported resource differs from the input")
+	nickname := attributes[venafiCertificateAttrNickname]
+	if nickname != data.nickname {
+		return fmt.Errorf("nickname in imported resource differs from the input")
 	}
 	return nil
 }
@@ -390,8 +390,8 @@ func createCertificate(t *testing.T, cfg *vcert.Config, data *testData, serviceG
 		t.Fatalf("error reading zone configuration: %s", err)
 	}
 	req := &certificate.Request{}
-	if data.object_name != "" && cfg.ConnectorType == endpoint.ConnectorTypeTPP {
-		t.Logf("Certificate: %s", data.object_name)
+	if data.nickname != "" && cfg.ConnectorType == endpoint.ConnectorTypeTPP {
+		t.Logf("Certificate: %s", data.nickname)
 	} else {
 		//at least cn mus be set for TPP
 		t.Logf("Certificate: %s", data.cn)
@@ -411,8 +411,8 @@ func createCertificate(t *testing.T, cfg *vcert.Config, data *testData, serviceG
 		req.IPAddresses = stringArrayToIParray(strings.Split(data.dns_ip, ","))
 	}
 	// this is the name that will show up on VaaS UI
-	if data.object_name != "" {
-		req.FriendlyName = data.object_name
+	if data.nickname != "" {
+		req.FriendlyName = data.nickname
 	}
 	if data.valid_days != 0 {
 		req.ValidityHours = data.valid_days * 24

--- a/venafi/test_util.go
+++ b/venafi/test_util.go
@@ -5,6 +5,9 @@ import (
 	"crypto/x509"
 	"encoding/pem"
 	"fmt"
+	"github.com/Venafi/vcert/v4"
+	"github.com/Venafi/vcert/v4/pkg/certificate"
+	"github.com/Venafi/vcert/v4/pkg/endpoint"
 	"github.com/Venafi/vcert/v4/pkg/util"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
@@ -307,6 +310,20 @@ func checkImportTppCertWithCustomFields(t *testing.T, data *testData, states []*
 	return nil
 }
 
+func checkImportWithObjectName(t *testing.T, data *testData, states []*terraform.InstanceState) error {
+	st := states[0]
+	attributes := st.Attributes
+	err := checkImportCert(t, data, attributes)
+	if err != nil {
+		return err
+	}
+	objectName := attributes["object_name"]
+	if objectName != data.object_name {
+		return fmt.Errorf("object name in imported resource differs from the input")
+	}
+	return nil
+}
+
 func checkImportCert(t *testing.T, data *testData, attr map[string]string) error {
 	certificate := attr["certificate"]
 	privateKey := attr["private_key_pem"]
@@ -340,4 +357,120 @@ func checkImportedCustomFields(t *testing.T, dataCf string, attr map[string]stri
 		}
 	}
 	return nil
+}
+
+func createCertificate(t *testing.T, cfg *vcert.Config, data *testData, serviceGenerated bool) {
+	t.Log("Creating certificate for testing")
+	cfg.Zone = data.zone
+
+	var auth = &endpoint.Authentication{}
+	if cfg.ConnectorType == endpoint.ConnectorTypeTPP {
+		cfg.BaseUrl = os.Getenv("TPP_URL")
+		cfg.Zone = os.Getenv("TPP_ZONE")
+		auth.AccessToken = os.Getenv("TPP_ACCESS_TOKEN")
+	} else if cfg.ConnectorType == endpoint.ConnectorTypeCloud {
+		cfg.BaseUrl = os.Getenv("CLOUD_URL")
+		cfg.Zone = os.Getenv("CLOUD_ZONE")
+		auth.APIKey = os.Getenv("CLOUD_APIKEY")
+	}
+	cfg.Credentials = auth
+	client, err := vcert.NewClient(cfg)
+	// here stops
+	zoneConfig, err := client.ReadZoneConfiguration()
+	if err != nil {
+		t.Fatalf("error reading zone configuration: %s", err)
+	}
+	req := &certificate.Request{}
+	if data.object_name != "" && cfg.ConnectorType == endpoint.ConnectorTypeTPP {
+		t.Log(fmt.Sprintf("Certificate: %s", data.object_name))
+	} else {
+		//at least cn mus be set for TPP
+		t.Log(fmt.Sprintf("Certificate: %s", data.cn))
+	}
+	if data.cn != "" {
+		req.Subject.CommonName = data.cn
+	}
+	if data.private_key_password != "" {
+		req.KeyPassword = data.private_key_password
+	}
+	req.Subject.Organization = []string{"Venafi, Inc."}
+	req.Subject.OrganizationalUnit = []string{"Automated Tests"}
+	if data.dns_ns != "" {
+		req.DNSNames = strings.Split(data.dns_ns, ",")
+	}
+	if data.dns_ip != "" {
+		req.IPAddresses = stringArrayToIParray(strings.Split(data.dns_ip, ","))
+	}
+	// this is the name that will show up on VaaS UI
+	if data.object_name != "" {
+		req.FriendlyName = data.object_name
+	}
+	if data.valid_days != 0 {
+		req.ValidityHours = data.valid_days * 24
+	}
+	req.IssuerHint = issuerHint
+	req.CsrOrigin = certificate.LocalGeneratedCSR
+	if serviceGenerated == true {
+		req.CsrOrigin = certificate.ServiceGeneratedCSR
+	}
+	err = client.GenerateRequest(zoneConfig, req)
+	if err != nil {
+		t.Fatalf("error generating request: %s", err)
+	}
+	t.Log("Requesting Certificate")
+	pickupID, err := client.RequestCertificate(req)
+	if err != nil {
+		t.Fatalf("error requesting certificate: %s", err)
+	}
+
+	req.PickupID = pickupID
+	req.ChainOption = certificate.ChainOptionRootLast
+
+	pcc, _ := certificate.NewPEMCollection(nil, nil, nil)
+	startTime := time.Now()
+	for {
+		if serviceGenerated == true {
+			req.Timeout = 180 * time.Second
+			req.KeyPassword = data.private_key_password
+			if cfg.ConnectorType == endpoint.ConnectorTypeTPP {
+				req.FetchPrivateKey = true
+			}
+		}
+		t.Log("Retrieving certificate")
+		pcc, err = client.RetrieveCertificate(req)
+		if err != nil {
+			_, ok := err.(endpoint.ErrCertificatePending)
+			if ok {
+				if time.Now().After(startTime.Add(time.Duration(600) * time.Second)) {
+					err = endpoint.ErrRetrieveCertificateTimeout{CertificateID: pickupID}
+					break
+				}
+				time.Sleep(time.Duration(10) * time.Second)
+				continue
+			}
+			break
+		}
+		break
+	}
+	if err != nil {
+		t.Fatalf("error retrieving certificate: %s", err)
+	}
+	t.Log("Verifying certificate")
+	p, _ := pem.Decode([]byte(pcc.Certificate))
+	cert, err := x509.ParseCertificate(p.Bytes)
+	if err != nil {
+		t.Fatalf("error parsing certificate: %s", err)
+	}
+
+	if data.valid_days != 0 {
+		certValidUntil := cert.NotAfter.Format("2006-01-02")
+		loc, _ := time.LoadLocation("UTC")
+		utcNow := time.Now().In(loc)
+		expectedValidDate := utcNow.AddDate(0, 0, data.valid_days).Format("2006-01-02")
+		// ensure certificate is created with our provided time
+		if expectedValidDate != certValidUntil {
+			t.Fatalf("Expiration date is different than expected, expected: %s, but got %s: ", expectedValidDate, certValidUntil)
+		}
+	}
+	t.Log("Certificate creation successful")
 }

--- a/venafi/test_util.go
+++ b/venafi/test_util.go
@@ -362,7 +362,6 @@ func checkImportedCustomFields(t *testing.T, dataCf string, attr map[string]stri
 
 func createCertificate(t *testing.T, cfg *vcert.Config, data *testData, serviceGenerated bool) {
 	t.Log("Creating certificate for testing")
-	cfg.Zone = data.zone
 
 	var auth = &endpoint.Authentication{}
 	if cfg.ConnectorType == endpoint.ConnectorTypeTPP {

--- a/venafi/util.go
+++ b/venafi/util.go
@@ -71,7 +71,7 @@ func sameStringSlice(x, y []string) bool {
 //nolint
 type testData struct {
 	cert                 string
-	object_name          string
+	nickname             string
 	private_key          string
 	private_key_password string
 	wrong_cert           string
@@ -182,8 +182,8 @@ func buildSshCertRequest(d *schema.ResourceData) certificate.SshCertRequest {
 			req.ValidityPeriod = strconv.Itoa(validHours) + "h"
 		}
 	}
-	if objectName, ok := d.Get("object_name").(string); ok {
-		req.ObjectName = objectName
+	if nickname, ok := d.Get(venafiCertificateAttrNickname).(string); ok {
+		req.ObjectName = nickname
 	}
 	if principals, ok := d.GetOk("principals"); ok {
 		req.Principals = getStringList(principals)

--- a/venafi/util.go
+++ b/venafi/util.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/pkg/errors"
 	"math/rand"
+	"net"
 	"strconv"
 	"strings"
 	"time"
@@ -70,6 +71,7 @@ func sameStringSlice(x, y []string) bool {
 //nolint
 type testData struct {
 	cert                 string
+	object_name          string
 	private_key          string
 	private_key_password string
 	wrong_cert           string
@@ -265,4 +267,12 @@ func validateStringListFromSchemaAttribute(array interface{}, attr string) error
 
 func buildStantardDiagError(msg string) diag.Diagnostics {
 	return diag.FromErr(fmt.Errorf(msg))
+}
+
+func stringArrayToIParray(arrayIPstring []string) []net.IP {
+	s := make([]net.IP, 0)
+	for _, ipString := range arrayIPstring {
+		s = append(s, net.ParseIP(ipString))
+	}
+	return s
 }

--- a/website/docs/r/venafi_certificate.html.markdown
+++ b/website/docs/r/venafi_certificate.html.markdown
@@ -119,9 +119,9 @@ The `id` for each platform is:
 
 **TPP:**
 
-The `nickname` of the certificate, which usually should always be the `common_name` as it is good practice. Internally we built the `pickup_id` using the `zone` defined at the provider block.
+The `nickname` of the certificate, which represents the name of the certificate object in TPP. Internally we built the `pickup_id` using the `zone` defined at the provider block.
 
-~>**Note:** The object name could differ conceptually of the common name, as there some use cases whenever you want to handle certificates with the same common names but different attributes (such as different SANs), you could manage many resources with the same common name using `for_each` and `count` meta arguments and object name attribute being different from the common name.
+~>**Note:** The certificate object name at TPP, usually, should be the same as the `common_name` provided as it is considered good practice, but the `nickname` actually could differ from the common name, as there some use cases whenever you want to handle certificates with different nicknames. For example, you could have certificates with same common name and different SANs, then, you could manage many certificate resources that share the same common name using `for_each` and `count` meta arguments.
 
 **VaaS:**
 

--- a/website/docs/r/venafi_certificate.html.markdown
+++ b/website/docs/r/venafi_certificate.html.markdown
@@ -8,7 +8,7 @@ Provides access to TLS key and certificate data in Venafi. This can be used to d
 
 # venafi_certificate
 
-!> We dropped support for RSA PKCS#1 formatted keys for TLS certificates in version 15.0 and also for EC Keys in 
+!> We dropped support for RSA PKCS#1 formatted keys for TLS certificates in version 15.0 and also for EC Keys in
 version 0.15.4 (you can find out more about this transition in [here](https://github.com/Venafi/vcert/releases/tag/v4.17.0)).
 For backward compatibility during Terraform state refresh please update to version 0.15.5 or above.
 
@@ -41,6 +41,8 @@ The following arguments are supported:
 ~>**Note:** Updating `expiration_window` will not trigger another resource to be created by itself, thus won't enroll a new certificate. This won't apply if the `expiration_window` constraint allows it, this means, if time to expire of the certificate is within the expiration window.
 
 * `common_name` - (Required, string) The common name of the certificate.
+
+* `object_name` - (Optional, string) Use to specify a name for the new certificate object that will be created and placed in a policy. Only valid for TPP.
 
 * `algorithm` - (Optional, string) Key encryption algorithm, either RSA or ECDSA.
   Defaults to "RSA".
@@ -117,7 +119,9 @@ The `id` for each platform is:
 
 **TPP:**
 
-The `common name` of the certificate, internally we built the `pickup_id` using the `zone` defined at the provider block.
+The `object_name` of the certificate, which usually should always be the `common_name` as it is good practice. Internally we built the `pickup_id` using the `zone` defined at the provider block.
+
+~>**Note:** The object name could differ conceptually of the common name, as there some use cases whenever you want to handle certificates with the same common names but different attributes (such as different SANs), you could manage many resources with the same common name using `for_each` and `count` meta arguments and object name attribute being different from the common name.
 
 **VaaS:**
 

--- a/website/docs/r/venafi_certificate.html.markdown
+++ b/website/docs/r/venafi_certificate.html.markdown
@@ -42,7 +42,7 @@ The following arguments are supported:
 
 * `common_name` - (Required, string) The common name of the certificate.
 
-* `object_name` - (Optional, string) Use to specify a name for the new certificate object that will be created and placed in a policy. Only valid for TPP.
+* `nickname` - (Optional, string) Use to specify a name for the new certificate object that will be created and placed in a policy. Only valid for TPP.
 
 * `algorithm` - (Optional, string) Key encryption algorithm, either RSA or ECDSA.
   Defaults to "RSA".
@@ -119,7 +119,7 @@ The `id` for each platform is:
 
 **TPP:**
 
-The `object_name` of the certificate, which usually should always be the `common_name` as it is good practice. Internally we built the `pickup_id` using the `zone` defined at the provider block.
+The `nickname` of the certificate, which usually should always be the `common_name` as it is good practice. Internally we built the `pickup_id` using the `zone` defined at the provider block.
 
 ~>**Note:** The object name could differ conceptually of the common name, as there some use cases whenever you want to handle certificates with the same common names but different attributes (such as different SANs), you could manage many resources with the same common name using `for_each` and `count` meta arguments and object name attribute being different from the common name.
 


### PR DESCRIPTION
Closes https://github.com/Venafi/terraform-provider-venafi/issues/94

We expose "nickname" when requesting a certificate so we have the ability to explicitly set object name of the certificate at TPP, which overrides the default behavior of using the common_name as the object name.

It also includes:
- Bug fix: We refactor verification function for certificate key-pair and also add it in certificate resource creation.
- Starts work for setting constants for our provider resource in order to make it less error prone
