### PR TITLE
feat(makefile): Updated release target on Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -106,7 +106,7 @@ collect_artifacts:
 	cp -rv $(DIST_DIR)/* artifacts
 
 release:
-	go get -u github.com/tcnksm/ghr
+	go install github.com/tcnksm/ghr
 	ghr -prerelease -n $$RELEASE_VERSION $$RELEASE_VERSION artifacts/
 
 clean:


### PR DESCRIPTION
Updated release target to use `go install` instead of `go get`

go get no longer installs plugins, only adds them to the go.mod