### PR TITLE
feat(token): Removes error thrown during provider config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.17.1 (October 2nd, 2023)
+Removes an error thrown during provider configuration. Instead the error is thrown at resource creation.
+This work is necessary to allow the venafi-token provider to successfully manage the tokens of this provider.
+
 ## 0.17.0 (September 25, 2023)
 Added support for client certificate as authentication method. Two attributes were added for this purpose: p12_cert_filename (filename of the pkcs12 bundle) and p12_cert_password (password of the pkcs12 bundle)
 Added support for client_id attribute to allow users to customize which application is requesting tokens 

--- a/venafi/provider.go
+++ b/venafi/provider.go
@@ -185,11 +185,6 @@ func providerConfigure(ctx context.Context, d *schema.ResourceData) (interface{}
 
 	if !accessTokenMethod && !clientCertMethod && !userPassMethod && !apiKeyMethod && !devMode {
 		tflog.Error(ctx, messageVenafiNoAuthProvided)
-		diags = append(diags, diag.Diagnostic{
-			Severity: diag.Error,
-			Summary:  messageVenafiClientInitFailed,
-			Detail:   fmt.Sprintf("%s: %s", messageVenafiConfigFailed, messageVenafiNoAuthProvided),
-		})
 		return nil, diags
 	}
 

--- a/venafi/util.go
+++ b/venafi/util.go
@@ -138,6 +138,10 @@ func getIssuerHint(is string) util.IssuerHint {
 
 func getConnection(ctx context.Context, meta interface{}) (endpoint.Connector, error) {
 	tflog.Info(ctx, "Building Venafi Connector")
+	if meta == nil {
+		return nil, fmt.Errorf("%s: %s", messageVenafiClientInitFailed, messageVenafiNoAuthProvided)
+	}
+
 	cfg := meta.(*vcert.Config)
 	cl, err := vcert.NewClient(cfg)
 	if err != nil {


### PR DESCRIPTION
When no authentication attributes are passed to the provider, an error is no longer thrown. This allows the provider to finish setup and plan. Instead, the error will be thrown when the resource attempts to connect to Venafi