### PR TITLE
fixes pipeline lint issues

### DIFF
--- a/venafi/resource_venafi_certificate.go
+++ b/venafi/resource_venafi_certificate.go
@@ -623,7 +623,7 @@ func enrollVenafiCertificate(ctx context.Context, d *schema.ResourceData, cl end
 		for i := 0; i < len(uriList); i += 1 {
 			uri, err := url.Parse(uriList[i])
 			if err != nil {
-				return fmt.Errorf("invalid URI: " + err.Error())
+				return fmt.Errorf("invalid URI: %s", err.Error())
 			}
 			req.URIs = append(req.URIs, uri)
 		}
@@ -735,7 +735,7 @@ func enrollVenafiCertificate(ctx context.Context, d *schema.ResourceData, cl end
 	tflog.Info(ctx, "Creating certificate resource: Verifying certificate key-pair")
 	err = verifyCertKeyPair(pcc.Certificate, pcc.PrivateKey, keyPassword)
 	if err != nil {
-		return fmt.Errorf(fmt.Sprintf("Could not add certificate resource to state. Certificate and private key mismatch. Err: %s", err.Error()))
+		return fmt.Errorf("Could not add certificate resource to state. Certificate and private key mismatch. Err: %s", err.Error())
 	}
 
 	if err = d.Set("certificate", pcc.Certificate); err != nil {
@@ -847,7 +847,7 @@ func resourceVenafiCertificateImport(ctx context.Context, d *schema.ResourceData
 	tflog.Info(ctx, "Importing Venafi certificate", logFields)
 
 	if id == "" {
-		return nil, fmt.Errorf(importIdFailEmpty)
+		return nil, errors.New(importIdFailEmpty)
 	}
 
 	parameters := strings.Split(id, ",")
@@ -856,19 +856,19 @@ func resourceVenafiCertificateImport(ctx context.Context, d *schema.ResourceData
 	var keyPassword string
 
 	if len(parameters) > 2 {
-		return nil, fmt.Errorf(importIdFailExceededValues)
+		return nil, errors.New(importIdFailExceededValues)
 	}
 
 	if len(parameters) >= 1 {
 		pickupID = parameters[0]
 		if pickupID == "" {
-			return nil, fmt.Errorf(importPickupIdFailEmpty)
+			return nil, errors.New(importPickupIdFailEmpty)
 		}
 	}
 	if len(parameters) == 2 {
 		keyPassword = parameters[1]
 		if keyPassword == "" {
-			return nil, fmt.Errorf(importKeyPasswordFailEmpty)
+			return nil, errors.New(importKeyPasswordFailEmpty)
 		}
 	}
 
@@ -881,7 +881,7 @@ func resourceVenafiCertificateImport(ctx context.Context, d *schema.ResourceData
 	vCertCfg := provConf.VCertConfig
 	zone := vCertCfg.Zone
 	if zone == "" {
-		return nil, fmt.Errorf(importZoneFailEmpty)
+		return nil, errors.New(importZoneFailEmpty)
 	}
 
 	cl, err := getConnection(ctx, meta)

--- a/venafi/test_util.go
+++ b/venafi/test_util.go
@@ -415,7 +415,7 @@ func createCertificate(t *testing.T, cfg *vcert.Config, data *testData, serviceG
 			cf = strings.ReplaceAll(cf, "\"", "")
 			k, v, err := parseCustomField(cf)
 			if err != nil {
-				t.Fatalf(err.Error())
+				t.Fatal(err)
 			}
 			list := strings.Split(v, "|")
 			for _, value := range list {

--- a/venafi/util.go
+++ b/venafi/util.go
@@ -243,27 +243,27 @@ func validateSshCertValues(d *schema.ResourceData) error {
 func validateStringListFromSchemaAttribute(array interface{}, attr string) error {
 	values, ok := array.([]interface{})
 	if !ok {
-		return fmt.Errorf(fmt.Sprintf("\"%s\" is not a list", attr))
+		return fmt.Errorf("\"%s\" is not a list", attr)
 	}
 
 	if len(values) <= 0 {
-		return fmt.Errorf(fmt.Sprintf("\"%s\" is empty", attr))
+		return fmt.Errorf("\"%s\" is empty", attr)
 	}
 
 	for _, value := range values {
 		valueString, ok := value.(string)
 		if !ok {
-			return fmt.Errorf(fmt.Sprintf("value inside list of attribute \"%s\" is not a string", attr))
+			return fmt.Errorf("value inside list of attribute \"%s\" is not a string", attr)
 		}
 		if valueString == "" {
-			return fmt.Errorf(fmt.Sprintf("value inside list of attribute \"%s\" an empty string", attr))
+			return fmt.Errorf("value inside list of attribute \"%s\" an empty string", attr)
 		}
 	}
 	return nil
 }
 
 func buildStandardDiagError(msg string) diag.Diagnostics {
-	return diag.FromErr(fmt.Errorf(msg))
+	return diag.FromErr(errors.New(msg))
 }
 
 func stringArrayToIParray(arrayIPstring []string) []net.IP {


### PR DESCRIPTION
Fixes following lint errors:

- printf: non-constant format string in call to fmt.Errorf
- printf: non-constant format string in call to (*testing.common).Fatalf
- SA1006: printf-style function with dynamic format string and no further arguments should use print-style function instead (staticcheck)
