### PR TITLE
feat: Ability to pass in a scope for certificate authentication

### DIFF
--- a/venafi/provider.go
+++ b/venafi/provider.go
@@ -10,10 +10,11 @@ import (
 	"os"
 	"strings"
 
+	"golang.org/x/crypto/pkcs12"
+
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"software.sslmate.com/src/go-pkcs12"
 
 	"github.com/Venafi/vcert/v5"
 	"github.com/Venafi/vcert/v5/pkg/endpoint"

--- a/venafi/provider.go
+++ b/venafi/provider.go
@@ -10,11 +10,10 @@ import (
 	"os"
 	"strings"
 
-	"golang.org/x/crypto/pkcs12"
-
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"software.sslmate.com/src/go-pkcs12"
 
 	"github.com/Venafi/vcert/v5"
 	"github.com/Venafi/vcert/v5/pkg/endpoint"
@@ -35,6 +34,7 @@ const (
 
 	utilityName           = "HashiCorp Terraform"
 	defaultClientID       = "hashicorp-terraform-by-venafi"
+	defaultScope          = "configuration:manage,delete;certificate:manage"
 	defaultSkipRetirement = false
 
 	// Environment variables for Provider attributes
@@ -50,6 +50,7 @@ const (
 	envVenafiP12Certificate = "VENAFI_P12_CERTIFICATE"
 	envVenafiP12Password    = "VENAFI_P12_PASSWORD"
 	envVenafiClientID       = "VENAFI_CLIENT_ID"
+	envVenafiScope          = "VENAFI_SCOPE"
 	envVenafiSkipRetirement = "VENAFI_SKIP_RETIREMENT"
 
 	// Attributes of the provider
@@ -66,6 +67,7 @@ const (
 	providerExternalJWT    = "external_jwt"
 	providerTrustBundle    = "trust_bundle"
 	providerClientID       = "client_id"
+	providerScope          = "scope"
 	providerSkipRetirement = "skip_retirement"
 
 	// Resource names
@@ -180,6 +182,12 @@ Example:
 				DefaultFunc: schema.EnvDefaultFunc(envVenafiClientID, defaultClientID),
 				Description: "application that will be using the token",
 			},
+			providerScope: {
+				Type:        schema.TypeString,
+				Optional:    true,
+				DefaultFunc: schema.EnvDefaultFunc(envVenafiScope, defaultScope),
+				Description: "Set application scopes less than or equal to that of the application itself",
+			},
 			providerSkipRetirement: {
 				Type:        schema.TypeBool,
 				Optional:    true,
@@ -222,6 +230,7 @@ func providerConfigure(ctx context.Context, d *schema.ResourceData) (interface{}
 	p12Certificate := d.Get(providerP12Cert).(string)
 	p12Password := d.Get(providerP12Password).(string)
 	clientID := d.Get(providerClientID).(string)
+	scope := d.Get(providerScope).(string)
 	skipRetirement := d.Get(providerSkipRetirement).(bool)
 	tokenURL := d.Get(providerTokenURL).(string)
 	externalJWT := d.Get(providerExternalJWT).(string)
@@ -259,6 +268,7 @@ func providerConfigure(ctx context.Context, d *schema.ResourceData) (interface{}
 		UserAgent:  &userAgent,
 		Credentials: &endpoint.Authentication{
 			ClientId: clientID,
+			Scope:    scope,
 		},
 	}
 


### PR DESCRIPTION
Attempts to fix #153.  ~~Requires #152 first as this includes the fix for #151.~~

Tested locally with my setup:

```log
2024-10-29T12:18:50.973Z [WARN]  ValidateProviderConfig from "provider[\"registry.terraform.io/venafi/venafi\"]" changed the config value, but that value is unused
2024-10-29T12:18:50.973Z [INFO]  provider.terraform-provider-venafi: Configuring venafi provider: tf_req_id=3791080c-596f-42a6-7290-0a45676e057f tf_rpc=Configure @caller=/Users/peter.fiddes/projects/venafi/terraform-provider-venafi/venafi/provider.go:221 @module=venafi tf_provider_addr=registry.terraform.io/Venafi/venafi timestamp=2024-10-29T12:18:50.973Z
2024-10-29T12:18:50.973Z [INFO]  provider.terraform-provider-venafi: User-Agent: hashicorp-terraform-by-venafi/nknown: @caller=/Users/peter.fiddes/projects/venafi/terraform-provider-venafi/venafi/provider.go:222 @module=venafi tf_provider_addr=registry.terraform.io/Venafi/venafi tf_req_id=3791080c-596f-42a6-7290-0a45676e057f tf_rpc=Configure timestamp=2024-10-29T12:18:50.973Z
2024-10-29T12:18:50.973Z [INFO]  provider.terraform-provider-venafi: Using `Venafi Trust Protection Platform` with url https://demo-1.tpp.peter-fiddes-gcp.jetstacker.net to issue certificate: tf_provider_addr=registry.terraform.io/Venafi/venafi tf_req_id=3791080c-596f-42a6-7290-0a45676e057f tf_rpc=Configure @caller=/Users/peter.fiddes/projects/venafi/terraform-provider-venafi/venafi/provider.go:285 @module=venafi timestamp=2024-10-29T12:18:50.973Z
2024-10-29T12:18:50.973Z [INFO]  provider.terraform-provider-venafi: Setting up TLS Configuration: tf_provider_addr=registry.terraform.io/Venafi/venafi tf_req_id=3791080c-596f-42a6-7290-0a45676e057f tf_rpc=Configure @caller=/Users/peter.fiddes/projects/venafi/terraform-provider-venafi/venafi/provider.go:398 @module=venafi timestamp=2024-10-29T12:18:50.973Z
2024-10-29T12:18:51.058Z [INFO]  provider.terraform-provider-venafi: vCert: Got 200 OK status for GET https://demo-1.tpp.peter-fiddes-gcp.jetstacker.net/vedsdk/: timestamp=2024-10-29T12:18:51.058Z
2024-10-29T12:18:51.058Z [INFO]  provider.terraform-provider-venafi: PFX certificate provided for authentication, getting access token: @module=venafi tf_provider_addr=registry.terraform.io/Venafi/venafi tf_req_id=3791080c-596f-42a6-7290-0a45676e057f tf_rpc=Configure @caller=/Users/peter.fiddes/projects/venafi/terraform-provider-venafi/venafi/provider.go:456 timestamp=2024-10-29T12:18:51.058Z
2024-10-29T12:18:51.192Z [INFO]  provider.terraform-provider-venafi: vCert: Got 200 OK status for POST https://demo-1.tpp.peter-fiddes-gcp.jetstacker.net/vedauth/authorize/certificate: timestamp=2024-10-29T12:18:51.192Z
2024-10-29T12:18:51.264Z [INFO]  provider.terraform-provider-venafi: vCert: Got 200 OK status for GET https://demo-1.tpp.peter-fiddes-gcp.jetstacker.net/vedsdk/Identity/Self: timestamp=2024-10-29T12:18:51.264Z
2024-10-29T12:18:51.264Z [INFO]  provider.terraform-provider-venafi: Successfully authenticated: tf_req_id=3791080c-596f-42a6-7290-0a45676e057f tf_rpc=Configure @caller=/Users/peter.fiddes/projects/venafi/terraform-provider-venafi/venafi/provider.go:467 @module=venafi tf_provider_addr=registry.terraform.io/Venafi/venafi timestamp=2024-10-29T12:18:51.264Z
2024-10-29T12:18:51.266Z [DEBUG] ReferenceTransformer: "venafi_policy.team[\"team-1\"]" references: []
2024-10-29T12:18:51.266Z [DEBUG] ReferenceTransformer: "venafi_policy.team[\"team-2\"]" references: []
2024-10-29T12:18:51.266Z [DEBUG] ReferenceTransformer: "venafi_policy.team[\"team-3\"]" references: []
venafi_policy.team["team-3"]: Refreshing state... [id=\VED\Policy\Terraform\team-3]
venafi_policy.team["team-2"]: Refreshing state... [id=\VED\Policy\Terraform\team-awesome]
venafi_policy.team["team-1"]: Refreshing state... [id=\VED\Policy\Terraform\team-1]
2024-10-29T12:18:51.275Z [DEBUG] provider.stdio: received EOF, stopping recv loop: err="rpc error: code = Unavailable desc = error reading from server: EOF"
2024-10-29T12:18:51.276Z [INFO]  provider: plugin process exited: plugin=/Users/peter.fiddes/projects/venafi/terraform-provider-venafi/terraform-provider-venafi id=71371
2024-10-29T12:18:51.276Z [DEBUG] provider: plugin exited
2024-10-29T12:18:51.276Z [DEBUG] no planned changes, skipping apply graph check
2024-10-29T12:18:51.276Z [INFO]  backend/local: plan operation completed
2024-10-29T12:18:51.276Z [INFO]  backend/local: writing plan output to: plan

No changes. Your infrastructure matches the configuration.

Terraform has compared your real infrastructure against your configuration and found no differences, so no changes are needed.
```

I have tested the following other scenarios:

1) Define `VENAFI_TOKEN`, `VENAFI_CLIENT_ID` & `VENAFI_SCOPE` explicitly in provider. All works with token.
1) Define `VENAFI_TOKEN` and leave clientID and scope to the code default values. All still works with token.