### PR TITLE
Fix for issue #171

### DIFF
--- a/venafi/provider.go
+++ b/venafi/provider.go
@@ -327,6 +327,7 @@ func providerConfigure(ctx context.Context, d *schema.ResourceData) (interface{}
 			Summary:  messageVenafiClientInitFailed,
 			Detail:   messageVenafiClientInitFailed + ": " + err.Error(),
 		})
+		return nil, diags
 	}
 
 	err = client.Ping()


### PR DESCRIPTION
The nil pointer happens when something is wrong with the configured trust bundle at the moment that this is used to get a VCertClient to connect to a given Venafi platform.

Fix for issue #171