### PR TITLE
Add support for setting CADN for certificates

### DIFF
--- a/venafi/resource_venafi_certificate.go
+++ b/venafi/resource_venafi_certificate.go
@@ -172,6 +172,13 @@ func resourceVenafiCertificate() *schema.Resource {
 				Computed:  true,
 				Sensitive: true,
 			},
+			"certificate_authority_dn": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: "The Distinguished Name (DN) of the Certificate Authority Template. This value is not required if it is defined by policy. Applies only to Venafi Trust Protection Platform.",
+				ForceNew:    true,
+			},
 			"chain": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -401,6 +408,14 @@ func resourceVenafiCertificateRead(ctx context.Context, d *schema.ResourceData, 
 	if err != nil {
 		return diag.FromErr(err)
 	}
+
+	if cl.GetType() == endpoint.ConnectorTypeTPP {
+		certMetadata, err := cl.RetrieveCertificateMetaData(pickupID)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+		d.Set("certificate_authority_dn", certMetadata.CertificateAuthorityDN)
+	}
 	return diags
 }
 
@@ -565,6 +580,9 @@ func enrollVenafiCertificate(ctx context.Context, d *schema.ResourceData, cl end
 		CsrOrigin:    certificate.LocalGeneratedCSR,
 		CustomFields: []certificate.CustomField{{Type: certificate.CustomFieldOrigin, Value: utilityName}},
 	}
+
+	cadn := d.Get("certificate_authority_dn").(string)
+	req.CADN = cadn
 
 	origin := d.Get("csr_origin").(string)
 	if origin == csrService {
@@ -837,6 +855,14 @@ func enrollVenafiCertificate(ctx context.Context, d *schema.ResourceData, cl end
 
 	if err = d.Set("private_key_pem", pcc.PrivateKey); err != nil {
 		return fmt.Errorf("error setting private key: %s", err)
+	}
+
+	if cl.GetType() == endpoint.ConnectorTypeTPP {
+		certMetadata, err := cl.RetrieveCertificateMetaData(pickupReq.PickupID)
+		if err != nil {
+			return err
+		}
+		d.Set("certificate_authority_dn", certMetadata.CertificateAuthorityDN)
 	}
 
 	return nil

--- a/website/docs/r/venafi_certificate.html.markdown
+++ b/website/docs/r/venafi_certificate.html.markdown
@@ -80,6 +80,8 @@ Defaults to `168`.
 
 * `tags` - (Optional, set of strings) List of Certificate Tags defined in Venafi Control Plane.
 
+* `certificate_authority_dn` - (Optional, string) The Distinguished Name (DN) of the Certificate Authority Template. This value is not required if it is defined by policy. Applies only to Venafi Trust Protection Platform.
+
 ## Attributes Reference
 
 The following attributes are exported:


### PR DESCRIPTION
connects #196 

There's a rough test for this here: https://github.com/aidy/terraform-provider-venafi/commit/34ae8b4f7f0a50c899ecddfca234f4b07a7d643b
I've not included it in this PR as it requires a further env var to be set (and a CA template to be configured), and I don't know how your tests are configured to be run, and I don't want that to be a blocker. Happy to include it if you'd like, though.