### PR TITLE
security: CWE-532: Prevent key password logging in import — VC-53754

### DIFF
--- a/venafi/resource_venafi_certificate.go
+++ b/venafi/resource_venafi_certificate.go
@@ -909,10 +909,6 @@ func AsPKCS12(certificate string, privateKey string, chain []string, keyPassword
 
 func resourceVenafiCertificateImport(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
 	id := d.Id()
-	logFields := map[string]interface{}{
-		"id": id,
-	}
-	tflog.Info(ctx, "Importing CyberArk certificate", logFields)
 
 	if id == "" {
 		return nil, errors.New(importIdFailEmpty)
@@ -939,6 +935,11 @@ func resourceVenafiCertificateImport(ctx context.Context, d *schema.ResourceData
 			return nil, errors.New(importKeyPasswordFailEmpty)
 		}
 	}
+
+	logFields := map[string]interface{}{
+		"pickup_id": pickupID,
+	}
+	tflog.Info(ctx, "Importing CyberArk certificate", logFields)
 
 	//casting meta interface to the expected *ProviderConfig
 	provConf, ok := meta.(*ProviderConfig)


### PR DESCRIPTION
## Summary

Fixed CWE-532 vulnerability where the key password was being logged in plaintext during certificate import operations.

## Finding

**CWE-532: Insertion of Sensitive Information into Log File**

The `resourceVenafiCertificateImport` function was logging the full import ID, which contains both the pickup ID and the key password separated by a comma. This exposed the password in Terraform log output when importing certificates.

Import ID format: `<pickup-id>,<key-password>`

## Remediation

Moved the logging statement to after the import ID has been parsed, and changed it to log only the pickup ID portion instead of the full ID containing the sensitive password.

**Changes:**
- Moved `tflog.Info` call to after parameter parsing
- Changed log field from `"id": id` to `"pickup_id": pickupID`
- Removed password exposure from logs while maintaining useful debugging information

## Verification

The fix ensures that:
- Only the pickup ID is logged, not the full import ID
- The key password is never written to Terraform logs
- Certificate import functionality remains unchanged
- Debugging capabilities are preserved with non-sensitive data

**Note:** Build and test failures are due to pre-existing Go toolchain environment issues, not related to this security fix.