### PR TITLE
security: CWE-522: Mark SSH private_key output as sensitive — VC-53753

### DIFF
--- a/venafi/resource_venafi_ssh_certificate.go
+++ b/venafi/resource_venafi_ssh_certificate.go
@@ -98,6 +98,7 @@ func resourceVenafiSshCertificate() *schema.Resource {
 				Type:        schema.TypeString,
 				Description: "Private key",
 				Computed:    true,
+				Sensitive:   true,
 			},
 			"principal": {
 				Type:          schema.TypeList,


### PR DESCRIPTION
## Summary

Fixes CWE-522: SSH private key output not marked sensitive in Terraform state.

## Finding

The `private_key` field in the `venafi_ssh_certificate` resource schema was not marked as `Sensitive: true`, allowing SSH private keys to be exposed in Terraform state files and logs.

## Remediation

Added `Sensitive: true` to the `private_key` schema field in `venafi/resource_venafi_ssh_certificate.go` (line 101). This ensures that:
- Private keys are redacted in Terraform output and logs
- Private keys are marked as sensitive in state files
- Private keys follow the same security pattern as `key_passphrase` (line 41)

## Verification

Build/test encountered environment issues (GOROOT configuration) unrelated to this change. The code change is minimal and syntactically correct:
- Single-line addition to schema definition
- Follows existing Terraform SDK patterns
- Consistent with `key_passphrase` field sensitivity marking